### PR TITLE
Fix scripts for instances which have been upgraded from Owncloud

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -6,8 +6,8 @@ set -eu
 app=$YNH_APP_INSTANCE_NAME
 
 # Set app specific variables
-dbname=$app
-dbuser=$app
+dbname=`sudo cat /var/www/$app/config/config.php  |grep dbname|sed "s|.*=> '\(.*\)'.*|\1|g"`
+dbuser=$dbname
 
 # Source app helpers
 source /usr/share/yunohost/helpers

--- a/scripts/remove
+++ b/scripts/remove
@@ -5,8 +5,8 @@ source ./_common.sh
 
 # Set app specific variables
 app=$APPNAME
-dbname=$app
-dbuser=$app
+dbname=`sudo cat /var/www/$app/config/config.php  |grep dbname|sed "s|.*=> '\(.*\)'.*|\1|g"`
+dbuser=$dbname
 
 # Source app helpers
 source /usr/share/yunohost/helpers

--- a/scripts/restore
+++ b/scripts/restore
@@ -5,10 +5,6 @@ set -eu
 # Get multi-instances specific variables
 app=$YNH_APP_INSTANCE_NAME
 
-# Set app specific variables
-dbname=$app
-dbuser=$app
-
 # Source app helpers
 source /usr/share/yunohost/helpers
 
@@ -53,6 +49,10 @@ sudo useradd -c "$app system account" \
 sudo cp -a ./www "$DESTDIR"
 sudo mkdir -p "$DATADIR"
 sudo cp -a ./data/. "$DATADIR"
+
+# Set app specific variables
+dbname=`sudo cat /var/www/$app/config/config.php  |grep dbname|sed "s|.*=> '\(.*\)'.*|\1|g"`
+dbuser=$dbname
 
 # Create and restore the database
 ynh_mysql_create_db "$dbname" "$dbuser" "$dbpass"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -7,8 +7,8 @@ source ./_common.sh
 
 # Set app specific variables
 app=$APPNAME
-dbname=$app
-dbuser=$app
+dbname=`sudo cat /var/www/$app/config/config.php  |grep dbname|sed "s|.*=> '\(.*\)'.*|\1|g"`
+dbuser=$dbname
 
 # Source app helpers
 source /usr/share/yunohost/helpers


### PR DESCRIPTION
Instances upgraded from owncloud keep a database named "owncloud", and current backup/restore scripts won't work with that setting, as they are looking for a database named after the app.

This patch adapts scripts to look for database name in Nextcloud config file.

Backup/restore/remove has been tested on a "pure" Nextcloud instance, and an instance upgraded from Owncloud. Upgrade script hasn't been tested.

The fix looks ugly:
- a cleaner way could be to store the dbname in the YunoHost app settings during install/upgrade, but that would need to think about people that have already done the merge (thus not storing a YunoHost app setting)
- the code could be factorized in _common.sh but that would only work for upgrade/remove. I couldn't find a way to access the _common.sh script in backup/restore scripts.