### PR TITLE
Corrections manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "package_format": 1,
+    "packaging_format": 1,
     "id": "nextcloud",
     "name": "Nextcloud",
     "description": {
@@ -7,7 +7,7 @@
         "fr": "Consultez et partagez vos fichiers, agendas, carnets d'adresses, emails et bien plus depuis les appareils de votre choix, sous vos conditions"
     },
     "url": "https://nextcloud.com",
-    "license": "AGPL-3",
+    "license": "free",
     "version": "10.0.1",
     "maintainer": {
         "name": "jerome",


### PR DESCRIPTION
Pour respecter les règles actuelles du manifest.
Concernant la licence, voir https://github.com/YunoHost/doc/pull/413