### PR TITLE
fix Missing YunoHost tile (#26) and blank page at login due to CSP scripts rules (#18)

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -20,6 +20,7 @@ location ^~ #LOCATION# {
   add_header X-Robots-Tag none;
   add_header X-Download-Options noopen;
   add_header X-Permitted-Cross-Domain-Policies none;
+  more_set_headers Content-Security-Policy "default-src 'self' 'unsafe-eval' data:;";
 
   # Set max upload size
   client_max_body_size 10G;
@@ -82,6 +83,7 @@ location ^~ #LOCATION# {
     add_header X-Robots-Tag none;
     add_header X-Download-Options noopen;
     add_header X-Permitted-Cross-Domain-Policies none;
+    more_set_headers Content-Security-Policy "default-src 'self' 'unsafe-eval' data:;";
     # Optional: Don't log access to assets
     access_log off;
   }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -20,7 +20,8 @@ location ^~ #LOCATION# {
   add_header X-Robots-Tag none;
   add_header X-Download-Options noopen;
   add_header X-Permitted-Cross-Domain-Policies none;
-  more_set_headers Content-Security-Policy "default-src 'self' 'unsafe-eval' data:;";
+  # Add data: to allow /ynhpanel.css to be load due to image on data:base64
+  more_set_headers Content-Security-Policy "default-src data:;";
 
   # Set max upload size
   client_max_body_size 10G;
@@ -83,7 +84,6 @@ location ^~ #LOCATION# {
     add_header X-Robots-Tag none;
     add_header X-Download-Options noopen;
     add_header X-Permitted-Cross-Domain-Policies none;
-    more_set_headers Content-Security-Policy "default-src 'self' 'unsafe-eval' data:;";
     # Optional: Don't log access to assets
     access_log off;
   }


### PR DESCRIPTION
add more headers to change nextcloud CSP.
yuonohost tile appears again