### PR TITLE
Possible HTTP-Splitting vulnerability

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -38,7 +38,7 @@ location ^~ #LOCATION# {
   #rewrite ^/.well-known/host-meta.json #PATH#/public.php?service=host-meta-json last;
 
   location #LOCATION# {
-    rewrite ^ #PATH#/index.php$uri;
+    rewrite ^ #PATH#/index.php$request_uri;
   }
 
   location = #PATH#/robots.txt {


### PR DESCRIPTION
Problem: [http_splitting] Possible HTTP-Splitting vulnerability.
Description: Using variables that can contain "\n" may lead to http injection.
Additional info: https://github.com/yandex/gixy/blob/master/docs/en/plugins/httpsplitting.md
Reason: At least variable "$uri" can contain "\n"

EDIT (frju365):
### PR REVIEW !
*Minor decision*
- [x] **Upgrade previous version** : Maniack C
- [x] **Code review** : frju365
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : frju365
- [x] **CI succeeded** : Maniack C