### PR TITLE
Added the php-ldap dependency

### DIFF
--- a/conf/nextcloud-deps.control
+++ b/conf/nextcloud-deps.control
@@ -6,7 +6,7 @@ Standards-Version: 3.9.2
 Package: nextcloud-deps
 Version: 11.0-1
 Depends: php5-gd, php5-json, php5-intl, php5-mcrypt
- , php5-curl, php5-apcu, php5-imagick
+ , php5-curl, php5-apcu, php5-imagick, php-ldap
  , acl, tar, smbclient
 Architecture: all
 Description: meta package for nextcloud dependencies


### PR DESCRIPTION
## Problem
- *Issue https://github.com/YunoHost-Apps/nextcloud_ynh/issues/69* 
```
Warning:   [Exception]
Warning:   App "LDAP user and group backend" cannot be installed because the following dependencies are not fulfilled: The library ldap is not available.
```
Dependency not installed : LDAP plugin of PHP.

## Solution
- *Install missing dependencies "php-ldap"*

## PR Status
Work finished. Could be reviewed and tested.

## Validation
---
*Minor decision*
- [ ] **Upgrade previous version** : 
- [X] **Code review** : frju365
- [ ] **Approval (LGTM)** : 
- [X] **Approval (LGTM)** : frju365 
- [ ] **CI succeeded** : 
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.