### PR TITLE
Fix restore with backup_core_only

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -106,7 +106,7 @@ datadir="/home/yunohost.app/${app}/data"
 
 # The data directory will be restored only if it exists in the backup archive
 # So only if it was backup previously.
-if [ -d "$YNH_BACKUP_DIR/data" ]
+if [ -d "$YNH_BACKUP_DIR/apps/$app/backup/home/yunohost.app/$app" ]
 then
 	ynh_restore_file "$datadir"
 else

--- a/scripts/restore
+++ b/scripts/restore
@@ -102,12 +102,16 @@ ynh_restore_file "/etc/logrotate.d/$app"
 # RESTORE THE DATA DIRECTORY
 #=================================================
 
+datadir="/home/yunohost.app/${app}/data"
+
 # The data directory will be restored only if it exists in the backup archive
 # So only if it was backup previously.
 if [ -d "$YNH_BACKUP_DIR/data" ]
 then
-	datadir="/home/yunohost.app/${app}/data"
 	ynh_restore_file "$datadir"
+else
+	# Create app folders
+	mkdir -p "$datadir"
 fi
 # Remove the option backup_core_only if it's in the settings.yml file
 ynh_app_setting_delete $app backup_core_only


### PR DESCRIPTION
## Problem
- *Restore script fail with `ligne 120: datadir : variable sans liaison`*

## Solution
- *Set datadir before the condition.*
- *And create the directory instead of restore it, if needed.*

## PR Status
Work finished. **Not tested**.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Upgrade previous version** : JimboJoe
- [x] **Code review** : frju365
- [x] **Approval (LGTM)** : frju365
- [x] **Approval (LGTM)** : JimboJoe
- [x] **CI succeeded** : JimboJoe
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_restore%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_restore%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.