### PR TITLE
Enable Redis file locking

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -7,7 +7,15 @@
     ],
     "updatechecker": false,
     "memcache.local": "\\OC\\Memcache\\APCu",
-    "integrity.check.disabled": true
+    "integrity.check.disabled": true,
+    "filelocking.enabled": true,
+    "memcache.locking": "\\OC\\Memcache\\Redis",
+    "redis": {
+      "host": "localhost",
+      "port": "6379",
+      "timeout": "0.0",
+      "password": ""
+     }
   },
   "apps": {
     "user_ldap": {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -23,7 +23,12 @@ location ^~ __PATH__ {
   # Set max upload size
   client_max_body_size 10G;
   fastcgi_buffers 64 4K;
-
+  
+  # Extend timeouts
+  client_body_timeout 60m;
+  proxy_read_timeout 60m;
+  fastcgi_read_timeout 60m;
+  
   # Disable gzip to avoid the removal of the ETag header
   gzip off;
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,7 +3,7 @@
 # COMMON VARIABLES
 #=================================================
 
-pkg_dependencies="php5-gd php5-json php5-intl php5-mcrypt php5-curl php5-apcu php5-imagick acl tar smbclient"
+pkg_dependencies="php5-gd php5-json php5-intl php5-mcrypt php5-curl php5-apcu php5-imagick imagemagick acl tar smbclient"
 
 #=================================================
 # COMMON HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,7 +3,7 @@
 # COMMON VARIABLES
 #=================================================
 
-pkg_dependencies="php5-gd php5-json php5-intl php5-mcrypt php5-curl php5-apcu php5-imagick imagemagick acl tar smbclient"
+pkg_dependencies="php5-gd php5-json php5-intl php5-mcrypt php5-curl php5-apcu php5-redis php5-imagick imagemagick acl tar smbclient"
 
 #=================================================
 # COMMON HELPERS


### PR DESCRIPTION
## Problem
- Gallery plugin doesn't work for accounts containing many files (timeout)
- Optimize global performance

## Solution
- Add ImageMagick dependency and tune timeouts for Gallery plugin
- For optimization reason, and as Redis is already running on a YunoHost instance, setup Nextcloud to use it by default (see documentation [here](https://docs.nextcloud.com/server/12.0/admin_manual/configuration_server/caching_configuration.html#small-organization-single-server-setup) and recommendation for Gallery plugin [here](https://github.com/nextcloud/gallery/wiki/Requirements#recommended)).
## PR Status

Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Upgrade previous version** : Maniack C
- [x] **Code review** : Maniack C
- [ ] **Approval (LGTM)** : 
- [x] **Approval (LGTM)** : Maniack C
- [x] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20enh_redis_locking%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20enh_redis_locking%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.