### PR TITLE
Fix duplicate log entry in logrotate

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -334,7 +334,7 @@ they are probably disabled and you'll have to manually enable them again." >&2
 #=================================================
 
 # Use logrotate to manage app-specific logfile(s)
-ynh_use_logrotate
+ynh_use_logrotate --non-append
 
 #=================================================
 # GENERIC FINALIZATION


### PR DESCRIPTION
## Problem
- *Upgrade script add another config at the end of logrotate config*
- *logrotate send an email every day: "error: nextcloud:37 duplicate log entry for /var/log/nextcloud/*.log"*

## Solution
- *Use --non-append option*

## PR Status
Work finished.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Upgrade previous version** : frju365 
- [x] **Code review** : frju365
- [x] **Approval (LGTM)** : frju365
- [x] **Approval (LGTM)** : JimboJoe 
- [x] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_log_rotate%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_log_rotate%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.