### PR TITLE
Fix cron config file rights and don't ovewrite all settings at upgrade

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -1,10 +1,5 @@
 {
   "system": {
-    "datadirectory": "#DATADIR#",
-    "trusted_domains": [
-      "localhost",
-      "#DOMAIN#"
-    ],
     "updatechecker": false,
     "memcache.local": "\\OC\\Memcache\\APCu",
     "integrity.check.disabled": true,

--- a/conf/config_install.json
+++ b/conf/config_install.json
@@ -1,0 +1,9 @@
+{
+  "system": {
+    "datadirectory": "#DATADIR#",
+    "trusted_domains": [
+      "localhost",
+      "#DOMAIN#"
+    ]
+  }
+}

--- a/scripts/install
+++ b/scripts/install
@@ -144,11 +144,6 @@ exec_occ maintenance:install \
 # CONFIGURE NEXTCLOUD
 #=================================================
 
-nc_conf="${final_path}/config.json"
-cp ../conf/config.json "$nc_conf"
-ynh_replace_string "#DOMAIN#" "$domain" "$nc_conf"
-ynh_replace_string "#DATADIR#" "$datadir" "$nc_conf"
-
 # Ensure that UpdateNotification app is disabled
 exec_occ app:disable updatenotification
 
@@ -156,7 +151,18 @@ exec_occ app:disable updatenotification
 exec_occ app:enable user_ldap
 exec_occ ldap:create-empty-config
 
-# Load the config file in nextcloud
+# Load the installation config file in nextcloud
+nc_conf="${final_path}/config_install.json"
+cp ../conf/config_install.json "$nc_conf"
+ynh_replace_string "#DOMAIN#" "$domain" "$nc_conf"
+ynh_replace_string "#DATADIR#" "$datadir" "$nc_conf"
+exec_occ config:import "$nc_conf"
+# Then remove it
+rm -f "$nc_conf"
+
+# Load the additional config file (used also for upgrade)
+nc_conf="${final_path}/config_install.json"
+cp ../conf/config.json "$nc_conf"
 exec_occ config:import "$nc_conf"
 # Then remove it
 rm -f "$nc_conf"

--- a/scripts/install
+++ b/scripts/install
@@ -216,6 +216,8 @@ ynh_store_file_checksum "${final_path}/config/config.php"
 
 cron_path="/etc/cron.d/$app"
 cp -a ../conf/nextcloud.cron "$cron_path"
+chown root: "$cron_path"
+chmod 644 "$cron_path"
 
 ynh_replace_string "#USER#" "$app" "$cron_path"
 ynh_replace_string "#DESTDIR#" "$final_path" "$cron_path"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -286,6 +286,8 @@ ynh_store_file_checksum "${final_path}/config/config.php"
 
 cron_path="/etc/cron.d/$app"
 cp -a ../conf/nextcloud.cron "$cron_path"
+chown root: "$cron_path"
+chmod 644 "$cron_path"
 
 ynh_replace_string "#USER#" "$app" "$cron_path"
 ynh_replace_string "#DESTDIR#" "$final_path" "$cron_path"


### PR DESCRIPTION
## Problem
* Cron file isn't created with proper rights, thus preventing cron job to be run (issue #88).
* Settings are all overwritten at upgrade, whereas some settings could have been legitimately modified by the user (see [this forum post](https://forum.yunohost.org/t/official-app-nextcloud/4104/14?u=jimbojoe))

## Solution
* fix cron config file rights
* separate settings for installation from settings that can be overwritten at upgrade.

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.  

## Validation
- [x] **Upgrade previous version** : Maniack C
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : frju365
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/view/Official/job/nextcloud_ynh%20fix_cron_dont_ovewrite_settings%20(Official)//badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/view/Official/job/nextcloud_ynh%20fix_cron_dont_ovewrite_settings%20(Official)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merge it.