### PR TITLE
Fix automatic logout from YunoHost when logging out from Nextcloud (#106)

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -175,9 +175,7 @@ do
     # If the current version has the same major version than the next one,
     # then it's the last upgrade to do
     if [ "$major_version" -eq "$current_major_version" ]; then
-	current_major_version=last
-	# Patch nexcloud files only for the last upgrade.
-	cp -a ../sources/patches_last_version ../sources/patches
+      current_major_version=last
     fi
 
     # Load the value for this version

--- a/scripts/upgrade.d/upgrade.last.sh
+++ b/scripts/upgrade.d/upgrade.last.sh
@@ -5,3 +5,6 @@ next_version="13.0.1"
 
 # Nextcloud tarball checksum sha256
 nextcloud_source_sha256="5743314a71e972ae46a14b36b37394d4545915aa5f32d9e12ba786d04c1f1d11"
+
+# Patch nextcloud files only for the last version
+cp -a ../sources/patches_last_version/* ../sources/patches

--- a/sources/patches_last_version/app-00-add-logout_url-conf.patch
+++ b/sources/patches_last_version/app-00-add-logout_url-conf.patch
@@ -1,14 +1,14 @@
 --- a/core/Controller/LoginController.php
 +++ b/core/Controller/LoginController.php
-@@ -100,7 +100,10 @@ class LoginController extends Controller {
+@@ -119,7 +119,10 @@
  		}
  		$this->userSession->logout();
- 
--		return new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm'));
+
+-		$response = new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm'));
 +		$redirectUrl = $this->config->getSystemValue('logout_url',
 +			$this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm')
 +		);
-+		return new RedirectResponse($redirectUrl);
++		$response = new RedirectResponse($redirectUrl);
+ 		$response->addHeader('Clear-Site-Data', '"cache", "cookies", "storage", "executionContexts"');
+ 		return $response;
  	}
- 
- 	/**


### PR DESCRIPTION
## Problem
- The [13.0.0 PR](https://github.com/YunoHost-Apps/nextcloud_ynh/pull/90) didn't adapt the source patch for logout feature
- Moreover, since [this PR](https://github.com/YunoHost-Apps/nextcloud_ynh/pull/99), source patches weren't applied any more on install

## Solution
- fix Nextcloud source patch
- fix patches not applied on installation (use `upgrade.last.sh` script which is used in install and upgrade)
- add an empty patches directory to work around a nasty cache issue when running package_check

## PR Status
Work finished.
Could be reviewed and tested: logging out from Nextcloud should log the user out of YunoHost and redirect to the YunoHost login screen.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : frju365
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_logout_patch%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_logout_patch%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.