### PR TITLE
Fix failed access after first installation (fixes #98)

### DIFF
--- a/hooks/post_user_create
+++ b/hooks/post_user_create
@@ -2,5 +2,4 @@
 
 user=$1
 
-sudo mkdir -p /home/$user
 sudo setfacl -m g:#GROUP#:rwx /home/$user

--- a/scripts/install
+++ b/scripts/install
@@ -183,6 +183,10 @@ exec_occ ldap:test-config \'\' \
 if [ $user_home -eq 1 ]; then
     exec_occ app:enable files_external
     create_external_storage "/home/\$user" "Home"
+    # Iterate over users to extend their home folder permissions
+    for u in $(ynh_user_list); do
+        setfacl -m g:$app:rwx "/home/$u" || true
+    done
 fi
 
 #=================================================
@@ -264,13 +268,6 @@ find ${datadir}/ -type f -print0 | xargs -0 chmod 0640
 find ${datadir}/ -type d -print0 | xargs -0 chmod 0750
 chmod 640 "${final_path}/config/config.php"
 chmod 755 /home/yunohost.app
-
-# Iterate over users to extend their home folder permissions - for the external
-# storage plugin usage - and create relevant Nextcloud directories
-for u in $(ynh_user_list); do
-    mkdir -p "${datadir}/${u}"
-    setfacl -m g:$app:rwx "/home/$u" || true
-done
 
 #=================================================
 # SETUP LOGROTATE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -271,6 +271,10 @@ if [ $user_home -eq 1 ]; then
     exec_occ files_external:list --output=json \
 	| grep -q '"storage":"\\\\OC\\\\Files\\\\Storage\\\\Local"' \
 	|| create_external_storage "/home/\$user" "Home"
+    # Iterate over users to extend their home folder permissions
+    for u in $(ynh_user_list); do
+      setfacl -m g:$app:rwx "/home/$u" || true
+    done
 fi
 
 #=================================================
@@ -328,13 +332,6 @@ find ${datadir}/ -type f -print0 | xargs -0 chmod 0640
 find ${datadir}/ -type d -print0 | xargs -0 chmod 0750
 chmod 640 "${final_path}/config/config.php"
 chmod 755 /home/yunohost.app
-
-# Iterate over users to extend their home folder permissions - for the external
-# storage plugin usage - and create relevant Nextcloud directories
-for u in $(ynh_user_list); do
-    mkdir -p "${datadir}/${u}"
-    setfacl -m g:$app:rwx "/home/$u" || true
-done
 
 #=================================================
 # WARNING ABOUT THIRD-PARTY APPS


### PR DESCRIPTION
## Problem
- *First access to Nextcloud can produce an Internal Server Error*

The error occurs for users existing prior to installation. The install script creates their corresponding internal data directory... with the wrong owner...

## Solution
- *Don't create the user data folder in install/upgrade scripts (it's automatically created by Nextcloud!), thus avoiding giving wrong ownership...*
- *modify  the post_user_create script accordingly*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : Josué
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_internal_server_error%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_internal_server_error%20(Official)/) 
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.