### PR TITLE
Fix Nextcloud apps upgrade (fixes #123)

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -202,7 +202,8 @@ do
 
     # Backup 3rd party applications from the current nextcloud
     # But do not overwrite if there is any upgrade
-    cp -a --update "$final_path/apps" "$tmpdir/apps"
+    # (apps directory already exists in Nextcloud archive)
+    cp -a --update "$final_path/apps" "$tmpdir"
 
     # Replace the old nextcloud by the new one
     ynh_secure_remove "$final_path"


### PR DESCRIPTION
## Problem
- *Existing applications not in Nextcloud base archive are not kept after upgrade*
- *There are numerous `apps` sub-directories in the `apps` directory (see #123)*


## Solution
- *Correctly copy existing apps in the new Nextcloud `apps` directory during upgrade*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : Josué
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_apps_upgrade%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_apps_upgrade%20(Official)/) 
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.