### PR TITLE
Don't use /tmp anymore

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -376,6 +376,8 @@ ynh_smart_mktemp () {
                 local tmpdir=/   
         elif is_there_enough_space /home; then
                 local tmpdir=/home
+        else
+		ynh_die "Insufficient free space to continue..."
         fi
 
         echo "$(sudo mktemp --directory --tmpdir="$tmpdir")"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -356,3 +356,27 @@ ynh_multimedia_addaccess () {
         groupadd -f multimedia
         usermod -a -G multimedia $user_name
 }
+
+ynh_smart_mktemp () {
+        local min_size="${1:-300}"
+        # Transform the minimum size from megabytes to kilobytes
+        min_size=$(( $min_size * 1024 ))
+
+        # Check if there's enough free space in a directory
+        is_there_enough_space () {
+                local free_space=$(df --output=avail "$1" | sed 1d)
+                test $free_space -ge $min_size
+        }
+
+        if is_there_enough_space /tmp; then
+                local tmpdir=/tmp
+        elif is_there_enough_space /var; then
+                local tmpdir=/var
+        elif is_there_enough_space /; then
+                local tmpdir=/   
+        elif is_there_enough_space /home; then
+                local tmpdir=/home
+        fi
+
+        echo "$(sudo mktemp --directory --tmpdir="$tmpdir")"
+}

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -189,7 +189,7 @@ do
     ynh_replace_string "__SHA256_SUM__" "$nextcloud_source_sha256" "../conf/app.src"
 
     # Create a temporary directory
-    tmpdir=$(mktemp -d)
+    tmpdir="${final_path}_temp_upgrade_dir"
 
     # Install the next nextcloud version in $tmpdir
     ynh_setup_source "$tmpdir"
@@ -208,6 +208,7 @@ do
     # Replace the old nextcloud by the new one
     ynh_secure_remove "$final_path"
     mv "$tmpdir" "$final_path"
+    ynh_secure_remove "$tmpdir"
 
     # Set write access for the following commands
     chown -R $app: "$final_path" "$datadir"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -189,7 +189,7 @@ do
     ynh_replace_string "__SHA256_SUM__" "$nextcloud_source_sha256" "../conf/app.src"
 
     # Create a temporary directory
-    tmpdir="${final_path}_temp_upgrade_dir"
+    tmpdir="$(ynh_smart_mktemp 300)"
 
     # Install the next nextcloud version in $tmpdir
     ynh_setup_source "$tmpdir"


### PR DESCRIPTION
## Problem
- *There's often problems with /tmp too small and blocking the upgrade of Nextcloud*
  - https://forum.yunohost.org/t/official-app-nextcloud/4104/70
  - https://forum.yunohost.org/t/tmp-too-small-to-update-nextcloud-app/5069

## Solution
- *Use a temporary directory in /var/www instead of /tmp since when /tmp is too small is generally because of an old YunoHost iso.*
- *Fix https://github.com/YunoHost-Apps/nextcloud_ynh/issues/109*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : frju365
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20donotusetmp%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20donotusetmp%20(Official)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
