### PR TITLE
Fix upgrade from for stretch

### DIFF
--- a/check_process
+++ b/check_process
@@ -12,7 +12,7 @@
 		setup_private=0
 		setup_public=0
 		upgrade=1
-		upgrade=1	from_commit=68c2f41da6b33bd8c949e5ba624bedba08c448be
+		upgrade=1	from_commit=1cdb9ea1619c6acaaa90bae88b5c4bed5084a2a7
 		backup_restore=1
 		multi_instance=0
 		incorrect_path=1
@@ -35,6 +35,6 @@
 Email=
 Notification=none
 ;;; Upgrade options
-	; commit=68c2f41da6b33bd8c949e5ba624bedba08c448be
-		name=Move patches to the right folder
+	; commit=1cdb9ea1619c6acaaa90bae88b5c4bed5084a2a7
+		name= Fix Debian Stretch dependencies by installing php-apcu, php-mbstring … 
 		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&user_home=1&


### PR DESCRIPTION
## Problem
- *"Upgrade from commit" fails in our CI because the current commit doesn't work on stretch.*

## Solution
- *Use the first commit available for stretch*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : Josué
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_upgrade_from%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_upgrade_from%20(Official)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.