### PR TITLE
[enh] move specific php.ini defines to the pool configuration

### DIFF
--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -397,3 +397,11 @@ php_value[upload_max_filesize] = 10G
 php_value[post_max_size] = 10G
 php_value[default_charset] = UTF-8
 php_value[always_populate_raw_post_data] = -1
+php_value[opcache.enable]=1
+php_value[opcache.enable_cli]=1
+php_value[opcache.interned_strings_buffer]=8
+php_value[opcache.max_accelerated_files]=10000
+php_value[opcache.memory_consumption]=128
+php_value[opcache.save_comments]=1
+php_value[opcache.revalidate_freq]=1
+

--- a/conf/php-fpm.ini
+++ b/conf/php-fpm.ini
@@ -1,7 +1,0 @@
-opcache.enable=1
-opcache.enable_cli=1
-opcache.interned_strings_buffer=8
-opcache.max_accelerated_files=10000
-opcache.memory_consumption=128
-opcache.save_comments=1
-opcache.revalidate_freq=1

--- a/scripts/backup
+++ b/scripts/backup
@@ -52,7 +52,6 @@ ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 
 ynh_backup "/etc/php5/fpm/pool.d/$app.conf"
-ynh_backup "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # BACKUP THE MYSQL DATABASE

--- a/scripts/restore
+++ b/scripts/restore
@@ -77,7 +77,6 @@ ynh_system_user_create $app
 #=================================================
 
 ynh_restore_file "/etc/php5/fpm/pool.d/$app.conf"
-ynh_restore_file "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # SPECIFIC RESTORATION


### PR DESCRIPTION
## Problem
Fix #138 

## Solution
Remove the php.ini file and integrate its content to the pool file
According to the ynh_add_fpm_config helper, the ini file is only processed if it exists.

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [X] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : Josué
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR139%20(Official_fork)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR139%20(Official_fork)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
