### PR TITLE
Set maintainer as "YunoHost Contributors"

### DIFF
--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -397,11 +397,3 @@ php_value[upload_max_filesize] = 10G
 php_value[post_max_size] = 10G
 php_value[default_charset] = UTF-8
 php_value[always_populate_raw_post_data] = -1
-php_value[opcache.enable]=1
-php_value[opcache.enable_cli]=1
-php_value[opcache.interned_strings_buffer]=8
-php_value[opcache.max_accelerated_files]=10000
-php_value[opcache.memory_consumption]=128
-php_value[opcache.save_comments]=1
-php_value[opcache.revalidate_freq]=1
-

--- a/conf/php-fpm.ini
+++ b/conf/php-fpm.ini
@@ -1,0 +1,7 @@
+opcache.enable=1
+opcache.enable_cli=1
+opcache.interned_strings_buffer=8
+opcache.max_accelerated_files=10000
+opcache.memory_consumption=128
+opcache.save_comments=1
+opcache.revalidate_freq=1

--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,8 @@
     "url": "https://nextcloud.com",
     "license": "AGPL-3.0",
     "maintainer": {
-        "name": "-",
-        "email": "-"
+        "name": "YunoHost Contributors",
+        "email": "apps@yunohost.org"
     },
     "requirements": {
         "yunohost": ">= 2.7.2"

--- a/scripts/backup
+++ b/scripts/backup
@@ -52,6 +52,7 @@ ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 
 ynh_backup "/etc/php5/fpm/pool.d/$app.conf"
+ynh_backup "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # BACKUP THE MYSQL DATABASE

--- a/scripts/restore
+++ b/scripts/restore
@@ -77,6 +77,7 @@ ynh_system_user_create $app
 #=================================================
 
 ynh_restore_file "/etc/php5/fpm/pool.d/$app.conf"
+ynh_restore_file "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # SPECIFIC RESTORATION


### PR DESCRIPTION
## Problem
- Some apps have dummy contributors, trying to uniformize a few things :P 

## Solution
- Set Nextcloud maintainer as "YunoHost Contributors" (like for Roundcube, c.f. https://github.com/YunoHost-Apps/roundcube_ynh/blob/master/manifest.json)

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20-BRANCH-%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20-BRANCH-%20(Official)/) *Please replace '-BRANCH-' in this link for a PR from a local branch.*  
or  
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-%20(Official_fork)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-%20(Official_fork)/) *Replace '-NUM-' by the PR number in this link for a PR from a forked repository.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
