### PR TITLE
Set maintainer as "YunoHost Contributors"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,8 @@
     "url": "https://nextcloud.com",
     "license": "AGPL-3.0",
     "maintainer": {
-        "name": "-",
-        "email": "-"
+        "name": "YunoHost Contributors",
+        "email": "apps@yunohost.org"
     },
     "requirements": {
         "yunohost": ">= 2.7.2"


### PR DESCRIPTION
## Problem
- Some apps have dummy contributors, trying to uniformize a few things :P 

## Solution
- Set Nextcloud maintainer as "YunoHost Contributors" (like for Roundcube, c.f. https://github.com/YunoHost-Apps/roundcube_ynh/blob/master/manifest.json)

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : frju365
- [x] **Approval (LGTM)** : frju365
- [x] **Approval (LGTM)** : Josué
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20-BRANCH-%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20-BRANCH-%20(Official)/) *Please replace '-BRANCH-' in this link for a PR from a local branch.*  
or  
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-%20(Official_fork)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-%20(Official_fork)/) *Replace '-NUM-' by the PR number in this link for a PR from a forked repository.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
