### PR TITLE
Plan required maintenance operations after upgrade

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,7 +3,7 @@
 # COMMON VARIABLES
 #=================================================
 
-pkg_dependencies="php5-gd php5-json php5-intl php5-mcrypt php5-curl php5-apcu php5-redis php5-ldap php5-imagick imagemagick acl tar smbclient"
+pkg_dependencies="php5-gd php5-json php5-intl php5-mcrypt php5-curl php5-apcu php5-redis php5-ldap php5-imagick imagemagick acl tar smbclient at"
 
 if [ "$(lsb_release --codename --short)" != "jessie" ]; then
 	pkg_dependencies="$pkg_dependencies php-zip php-apcu php-mbstring php-xml"

--- a/scripts/upgrade.d/upgrade.last.sh
+++ b/scripts/upgrade.d/upgrade.last.sh
@@ -8,3 +8,6 @@ nextcloud_source_sha256="4f5dd15a71694bd2f15fba0d2f942e5a5b1f5aba13511c507a23324
 
 # Patch nextcloud files only for the last version
 cp -a ../sources/patches_last_version/* ../sources/patches
+
+# Execute post-upgrade operations later on
+(cd /tmp ; at now + 10 minutes <<< "(cd $final_path ; sudo -u nextcloud php occ db:add-missing-indices ; sudo -u nextcloud php occ db:convert-filecache-bigint -n) > /tmp/nextcloud_maintenance.log")


### PR DESCRIPTION
## Problem
- *Some maintenance operations are needed after upgrade, otherwise warnings appear in Nextcloud administration overview*

## Solution
- *Apply recommended maintenance operations a little while after upgrade in order to let the upgrade finish and not block the upgrade process (these operations can last long on existing instances with already much data)*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : frju365
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : frju365
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20enh_upgrade_maintenance%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20enh_upgrade_maintenance%20(Official)/)

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
