### PR TITLE
Fix patches not applied on installation

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -79,6 +79,8 @@ ynh_replace_string "__VERSION__" "$next_version" "../conf/app.src"
 ynh_replace_string "__SHA256_SUM__" "$nextcloud_source_sha256" "../conf/app.src"
 
 ynh_app_setting_set $app final_path $final_path
+# Enable YunoHost patches on Nextcloud sources
+cp -a ../sources/patches_last_version/* ../sources/patches
 # Download, check integrity, uncompress and patch the source from app.src
 ynh_setup_source "$final_path"
 


### PR DESCRIPTION
## Problem
- *Following last changes for upgrade, YunoHost patches aren't applied any more on Nextcloud at installation*

## Solution
- *specifically apply patches during installation*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Anmol
- [x] **Approval (LGTM)** : Anmol
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_patches_on_install%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_patches_on_install%20(Official)/)