### PR TITLE
Maintenance operations: fix user for multi-instance and apply at installation

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -237,6 +237,11 @@ ynh_replace_string "#DESTDIR#" "$final_path" "$cron_path"
 exec_occ background:cron
 
 #=================================================
+# POST-INSTALL MAINTENANCE
+#=================================================
+(cd /tmp ; at now + 10 minutes <<< "(cd $final_path ; sudo -u $app php occ db:add-missing-indices ; sudo -u $app php occ db:convert-filecache-bigint -n) > /tmp/nextcloud_maintenance.log")
+
+#=================================================
 # CONFIGURE THE HOOK FILE FOR USER CREATE
 #=================================================
 

--- a/scripts/upgrade.d/upgrade.last.sh
+++ b/scripts/upgrade.d/upgrade.last.sh
@@ -12,5 +12,5 @@ last_upgrade_operations () {
   cp -a ../sources/patches_last_version/* ../sources/patches
 
   # Execute post-upgrade operations later on
-  (cd /tmp ; at now + 10 minutes <<< "(cd $final_path ; sudo -u nextcloud php occ db:add-missing-indices ; sudo -u nextcloud php occ db:convert-filecache-bigint -n) > /tmp/nextcloud_maintenance.log")
+  (cd /tmp ; at now + 10 minutes <<< "(cd $final_path ; sudo -u $app php occ db:add-missing-indices ; sudo -u $app php occ db:convert-filecache-bigint -n) > /tmp/nextcloud_maintenance.log")
 }


### PR DESCRIPTION


## Problem
- *Nextcloud maintenance operations aren't applied with the right user in case of multiple instances*
- *Some maintenance operations are needed after first installation*

## Solution
- *Use the appropriate $app user to execute maintenance operations*
- *Plan maintenance operations after installation*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_maintenance_user%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix_maintenance_user%20(Official)/) 
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
