### PR TITLE
Upgrade to upstream version 15.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Nextcloud for YunoHost
 own data. A personal cloud which run on your own server. With Nextcloud
 you can synchronize your files over your devices.
 
-**Shipped version:** 15.0.2
+**Shipped version:** 15.0.4
 
 [![Install Nextcloud with YunoHost](https://install-app.yunohost.org/install-with-yunohost.png)](https://install-app.yunohost.org/?app=nextcloud)
 ![](https://raw.githubusercontent.com/nextcloud/screenshots/master/files/Files%20Overview.png)

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -13,23 +13,23 @@ location ^~ __PATH__ {
   }
 
   # Add headers to serve security related headers
-  add_header Strict-Transport-Security "max-age=15768000;";
-  add_header X-Content-Type-Options nosniff;
-  add_header X-XSS-Protection "1; mode=block";
-  add_header X-Robots-Tag none;
-  add_header X-Download-Options noopen;
-  add_header X-Permitted-Cross-Domain-Policies none;
-  add_header Referrer-Policy no-referrer;
+  more_set_headers "Strict-Transport-Security: max-age=15768000";
+  more_set_headers "X-Content-Type-Options: nosniff";
+  more_set_headers "X-XSS-Protection: 1; mode=block";
+  more_set_headers "X-Robots-Tag: none";
+  more_set_headers "X-Download-Options: noopen";
+  more_set_headers "X-Permitted-Cross-Domain-Policies: none";
+  more_set_headers "Referrer-Policy: no-referrer";
 
   # Set max upload size
   client_max_body_size 10G;
   fastcgi_buffers 64 4K;
-  
+
   # Extend timeouts
   client_body_timeout 60m;
   proxy_read_timeout 60m;
   fastcgi_read_timeout 60m;
-  
+
   # Disable gzip to avoid the removal of the ETag header
   gzip off;
 
@@ -78,15 +78,15 @@ location ^~ __PATH__ {
 
   # Adding the cache control header for js and css files
   location ~* \.(?:css|js)$ {
-    add_header Cache-Control "public, max-age=7200";
+    more_set_headers "Cache-Control: public, max-age=7200";
     # Add headers to serve security related headers
-    add_header Strict-Transport-Security "max-age=15768000;";
-    add_header X-Content-Type-Options nosniff;
-    add_header X-XSS-Protection "1; mode=block";
-    add_header X-Robots-Tag none;
-    add_header X-Download-Options noopen;
-    add_header X-Permitted-Cross-Domain-Policies none;
-    add_header Referrer-Policy no-referrer;
+    more_set_headers "Strict-Transport-Security: max-age=15768000";
+    more_set_headers "X-Content-Type-Options: nosniff";
+    more_set_headers "X-XSS-Protection: 1; mode=block";
+    more_set_headers "X-Robots-Tag: none";
+    more_set_headers "X-Download-Options: noopen";
+    more_set_headers "X-Permitted-Cross-Domain-Policies: none";
+    more_set_headers "Referrer-Policy: no-referrer";
 
     # Optional: Don't log access to assets
     access_log off;

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Access & share your files, calendars, contacts, mail & more from any device, on your terms",
         "fr": "Consultez et partagez vos fichiers, agendas, carnets d'adresses, emails et bien plus depuis les appareils de votre choix, sous vos conditions"
     },
-    "version": "15.0.2~ynh1",
+    "version": "15.0.4~ynh1",
     "url": "https://nextcloud.com",
     "license": "AGPL-3.0",
     "maintainer": {

--- a/scripts/upgrade.d/upgrade.last.sh
+++ b/scripts/upgrade.d/upgrade.last.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Last available nextcloud version
-next_version="15.0.2"
+next_version="15.0.4"
 
 # Nextcloud tarball checksum sha256
-nextcloud_source_sha256="c1f4cc33e39994ddbe6777370b62c30b7ae52136a0530c0b9922770803ca0fea"
+nextcloud_source_sha256="f87db047c174f563e391a22c959d9ace767ca14ef0f97fc394f3061fc63d8f77"
 
 # This function will only be executed upon applying the last upgrade referenced above
 last_upgrade_operations () {


### PR DESCRIPTION
## Problem
- *The app isn't up-to-date*
- *Due to recent [core changes](https://github.com/YunoHost/yunohost/commit/8cb029a55e471e1ece3a8a2d7bba00975a6f2d17), security headers are declared twice, raising warnings in Nextcloud administration panel*

## Solution
- *Upgrade to latest version 15.0.4*
- *Adapt nginx configuration to the specific YunoHost context*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [x] **Approval (LGTM)** : Anmol
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20enh_update_15.0.4%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20enh_update_15.0.4%20(Official)/)
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
