### PR TITLE
Quote around variables to avoid miserably crashing if variable is empty

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -49,7 +49,7 @@ fi
 current_version=$(grep OC_VersionString "$final_path/version.php" | cut -d\' -f2)
 current_major_version=${current_version%%.*}
 
-if [ $current_major_version -gt 11 ]
+if [ "$current_major_version" -gt 11 ]
 then
     # Inform the backup/restore process that it should not save the data directory
     ynh_app_setting_set $app backup_core_only 1
@@ -73,7 +73,7 @@ ynh_abort_if_errors
 #=================================================
 
 ynh_handle_app_migration "owncloud" "owncloud_migration"
-if [ $migration_process -eq 1 ]
+if [ "$migration_process" -eq 1 ]
 then
     # If a migration has been perform
     # Reload some values changed by the migration process
@@ -270,7 +270,7 @@ exec_occ config:system:get logout_url >/dev/null 2>&1 \
 #=================================================
 
 # Enable External Storage and create local mount to home folder as needed
-if [ $user_home -eq 1 ]; then
+if [ "$user_home" -eq 1 ]; then
     exec_occ app:enable files_external
     exec_occ files_external:list --output=json \
 	| grep -q '"storage":"\\\\OC\\\\Files\\\\Storage\\\\Local"' \
@@ -372,7 +372,7 @@ systemctl reload nginx
 # FINISH MIGRATION PROCESS
 #=================================================
 
-if [ $migration_process -eq 1 ]
+if [ "$migration_process" -eq 1 ]
 then
     echo "ownCloud has been successfully migrated to Nextcloud! \
 A last scheduled operation will run in a couple of minutes to finish the \


### PR DESCRIPTION
## Problem

c.f. https://forum.yunohost.org/t/nextcloud-mise-a-jour-impossible/7199/25 ... Turns out variable was empty

## Solution

Having quotes around variables where you can't 100% sure won't be empty doesn't cost much :s 

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR166%20(Official_fork)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR166%20(Official_fork)/)
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
