### PR TITLE
[fix] Copy only app missing in new apps dir

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -205,6 +205,7 @@ do
     # Backup 3rd party applications from the current nextcloud
     # But do not overwrite if there is any upgrade
     # (apps directory already exists in Nextcloud archive)
+    touch -t 197001010000 $final_path/apps/.
     cp -a --update "$final_path/apps" "$tmpdir"
 
     # Replace the old nextcloud by the new one


### PR DESCRIPTION
## Problem
https://github.com/YunoHost-Apps/nextcloud_ynh/issues/168

## Solution
I suggest to change the date of all apps to 1970, like that we are sure the cp --update will not erase a new app version.

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20-BRANCH-%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20-BRANCH-%20(Official)/) *Please replace '-BRANCH-' in this link for a PR from a local branch.*  
or  
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-%20(Official_fork)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-%20(Official_fork)/) *Replace '-NUM-' by the PR number in this link for a PR from a forked repository.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
