### PR TITLE
Quickfix for path traversal issue

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -6,7 +6,7 @@ location = /.well-known/caldav {
 }
 
 location ^~ __PATH__ {
-  alias __FINALPATH__/;
+  alias __FINALPATH__;
 
   if ($scheme = http) {
     rewrite ^ https://$server_name$request_uri? permanent;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -5,8 +5,9 @@ location = /.well-known/caldav {
   return 301 https://$server_name__PATH__/remote.php/dav;
 }
 
-location ^~ __PATH__ {
-  alias __FINALPATH__;
+#sub_path_only rewrite ^__PATH__$ __PATH__/ permanent;
+location ^~ __PATH__/ {
+  alias __FINALPATH__/;
 
   if ($scheme = http) {
     rewrite ^ https://$server_name$request_uri? permanent;
@@ -42,7 +43,7 @@ location ^~ __PATH__ {
   #rewrite ^/.well-known/host-meta __PATH__/public.php?service=host-meta last;
   #rewrite ^/.well-known/host-meta.json __PATH__/public.php?service=host-meta-json last;
 
-  location __PATH__ {
+  location __PATH__/ {
     rewrite ^ __PATH__/index.php$request_uri;
   }
 


### PR DESCRIPTION
## Problem

Soooo, turns out that nextcloud is vulnerable to path traveral issues ... Going to https://domain.tld/nextcloud../html/index.nginx-debian.html might show you the nginx page... Sometime it only shows a blank white page, not sure why, but even then I can access some other dummy files (so, possibly secrets stored in other apps folders...)

Since nextcloud is one of the most used app it's a bit critical to fix this issue I guess..

## Solution

Apparently, the path traversal issues requires specific ingredient to work : 
- a `location /foo` *without* the `/` at the end
- an `alias` statement to `/var/www/foo/` *with* a `/` at the end ...

Here I simply removed the `/` at the end as it seems to be the easiest solution to fix this... But I didn't test it :/ At least the discussion is opened :stuck_out_tongue_winking_eye: :sweat_smile: 

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix-path-traversal-issue%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20fix-path-traversal-issue%20(Official)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.