### PR TITLE
[fix] Quick fix for backup_core_only feature with the old backup.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Access & share your files, calendars, contacts, mail & more from any device, on your terms",
         "fr": "Consultez et partagez vos fichiers, agendas, carnets d'adresses, emails et bien plus depuis les appareils de votre choix, sous vos conditions"
     },
-    "version": "15.0.5~ynh1",
+    "version": "15.0.5~ynh2",
     "url": "https://nextcloud.com",
     "license": "AGPL-3.0",
     "maintainer": {

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -56,8 +56,16 @@ current_major_version=${current_version%%.*}
 
 if [ $current_major_version -gt 11 ]
 then
+    # Inform the backup/restore process that it should not save the data directory
+    # Use only for the previous backup script that doesn't set 'is_big'
+    ynh_app_setting_set $app backup_core_only 1
+
     # Backup the current version of the app
     ynh_backup_before_upgrade
+
+    # Remove the option backup_core_only after the backup.
+    ynh_app_setting_delete $app backup_core_only
+
     ynh_clean_setup () {
 		# Remove the post migration script before its execution !
 		ynh_secure_remove "/tmp/owncloud_post_migration.sh" 2>&1


### PR DESCRIPTION
## Problem
- *https://forum.yunohost.org/t/nextcloud-failed-update-and-restore/7565/9*
- *Fix https://github.com/YunoHost-Apps/nextcloud_ynh/issues/185*

## Solution
- *Keep `backup_core_only` for compatibility with the previous backup script.*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [x] **Approval (LGTM)** : Kay0u
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR186/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR186/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.