### PR TITLE
[fix] backup_core_only settings doesn't work

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -28,6 +28,16 @@ domain=$(ynh_app_setting_get $app domain)
 db_name=$(ynh_app_setting_get $app db_name)
 
 #=================================================
+# APPLY BACKUP CORE ONLY POLICY
+#=================================================
+# Apply policy only if we are not in upgrade mode
+BACKUP_CORE_ONLY=${BACKUP_CORE_ONLY:-default}
+if [ "$BACKUP_CORE_ONLY" == "default" ] ; then
+    BACKUP_CORE_ONLY=$(ynh_app_setting_get $app backup_core_only)
+    BACKUP_CORE_ONLY=${BACKUP_CORE_ONLY:-0}
+fi
+
+#=================================================
 # STANDARD BACKUP STEPS
 #=================================================
 # BACKUP THE APP MAIN DIR

--- a/scripts/backup
+++ b/scripts/backup
@@ -31,8 +31,8 @@ db_name=$(ynh_app_setting_get $app db_name)
 # APPLY BACKUP CORE ONLY POLICY
 #=================================================
 # Apply policy only if we are not in upgrade mode
-BACKUP_CORE_ONLY=${BACKUP_CORE_ONLY:-default}
-if [ "$BACKUP_CORE_ONLY" == "default" ] ; then
+BACKUP_CORE_ONLY=${BACKUP_CORE_ONLY:-auto}
+if [ "$BACKUP_CORE_ONLY" == "auto" ] ; then
     BACKUP_CORE_ONLY=$(ynh_app_setting_get $app backup_core_only)
     BACKUP_CORE_ONLY=${BACKUP_CORE_ONLY:-0}
 fi


### PR DESCRIPTION
## Problem
https://github.com/YunoHost-Apps/nextcloud_ynh/issues/79

## Solution
Apply the backup core only env var if present in settings and we aren not in upgrade mode

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR196/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
