### PR TITLE
Fix scope of exec_occ and create_external_storage functions

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -182,6 +182,18 @@ exec_occ() {
     php occ --no-interaction --no-ansi "$@")
 }
 
+# Define a function to add an external storage
+# Create the external storage for the given folders and enable sharing
+create_external_storage() {
+local datadir="$1"
+local mount_name="$2"
+local mount_id=`exec_occ files_external:create --output=json \
+    "$mount_name" 'local' 'null::null' -c "datadir=$datadir" || true`
+! [[ $mount_id =~ ^[0-9]+$ ]] \
+    && ynh_print_warn --message="Unable to create external storage" \
+    || exec_occ files_external:option "$mount_id" enable_sharing true
+}
+
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
     ynh_script_progression --message="Upgrading nextcloud..." --weight=3
@@ -322,18 +334,6 @@ then
     #=================================================
     # MOUNT HOME FOLDERS AS EXTERNAL STORAGE
     #=================================================
-
-    # Define a function to add an external storage
-    # Create the external storage for the given folders and enable sharing
-    create_external_storage() {
-    local datadir="$1"
-    local mount_name="$2"
-    local mount_id=`exec_occ files_external:create --output=json \
-        "$mount_name" 'local' 'null::null' -c "datadir=$datadir" || true`
-    ! [[ $mount_id =~ ^[0-9]+$ ]] \
-        && ynh_print_warn --message="Unable to create external storage" \
-        || exec_occ files_external:option "$mount_id" enable_sharing true
-    }
 
     # Enable External Storage and create local mount to home folder as needed
     if [ $user_home -eq 1 ]; then

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -193,6 +193,8 @@ local mount_id=`exec_occ files_external:create --output=json \
     && ynh_print_warn --message="Unable to create external storage" \
     || exec_occ files_external:option "$mount_id" enable_sharing true
 }
+# Define app's data directory
+datadir="/home/yunohost.app/$app/data"
 
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
@@ -201,9 +203,6 @@ then
     # Load the last available version
     source upgrade.d/upgrade.last.sh
     last_version=$next_version
-
-    # Define app's data directory
-    datadir="/home/yunohost.app/$app/data"
 
     # Set write access for the following commands
     chown -R $app: "$final_path" "$datadir"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -176,15 +176,15 @@ ynh_install_app_dependencies $pkg_dependencies
 # VERSION TO THE NEXT ONE
 #=================================================
 
+# Define a function to execute commands with `occ`
+exec_occ() {
+(cd "$final_path" && exec_as "$app" \
+    php occ --no-interaction --no-ansi "$@")
+}
+
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
     ynh_script_progression --message="Upgrading nextcloud..." --weight=3
-
-    # Define a function to execute commands with `occ`
-    exec_occ() {
-    (cd "$final_path" && exec_as "$app" \
-        php occ --no-interaction --no-ansi "$@")
-    }
 
     # Load the last available version
     source upgrade.d/upgrade.last.sh


### PR DESCRIPTION
## Problem
- *A package upgrade without upstream version update fails (see forum post [here](https://forum.yunohost.org/t/official-app-nextcloud/4104/278?u=jimbojoe)*

## Solution
- *Change the scope of the `exec_occ` and `create_external_storage` function, which are needed even if there is no change of the upstream version*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : Kay0u
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR218/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR218/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
