### PR TITLE
Avoid OPcache errors (fixes #209)

### DIFF
--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -433,7 +433,10 @@ env[PATH] = $PATH
 php_value[upload_max_filesize] = 10G
 php_value[post_max_size] = 10G
 php_value[default_charset] = UTF-8
-php_value[opcache.enable]=1
+; OPcache is already activated by default
+; php_value[opcache.enable]=1
+; The following parameters are nevertheless recommended for Nextcloud
+; see here: https://docs.nextcloud.com/server/15/admin_manual/installation/server_tuning.html#enable-php-opcache
 php_value[opcache.enable_cli]=1
 php_value[opcache.interned_strings_buffer]=8
 php_value[opcache.max_accelerated_files]=10000


### PR DESCRIPTION
## Problem
- *There are recurrent error messages about Zend OPcache (see #209)*

## Solution
- *Remove redundant OPcache enabling parameter*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : Kay0u
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR219/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR219/)   
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
