### PR TITLE
Do not use too much process for php

### DIFF
--- a/conf/extra_php-fpm.conf
+++ b/conf/extra_php-fpm.conf
@@ -1,0 +1,15 @@
+
+; Additional php.ini defines, specific to this pool of workers.
+php_value[upload_max_filesize] = 10G
+php_value[post_max_size] = 10G
+php_value[default_charset] = UTF-8
+; OPcache is already activated by default
+; php_value[opcache.enable]=1
+; The following parameters are nevertheless recommended for Nextcloud
+; see here: https://docs.nextcloud.com/server/15/admin_manual/installation/server_tuning.html#enable-php-opcache
+php_value[opcache.enable_cli]=1
+php_value[opcache.interned_strings_buffer]=8
+php_value[opcache.max_accelerated_files]=10000
+php_value[opcache.memory_consumption]=128
+php_value[opcache.save_comments]=1
+php_value[opcache.revalidate_freq]=1

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -1,0 +1,26 @@
+version = "0.1"
+name = "Nextcloud configuration panel"
+
+[main]
+name = "Nextcloud configuration"
+
+    [main.php_fpm_config]
+    name = "PHP-FPM configuration"
+
+        [main.php_fpm_config.footprint]
+        ask = "Memory footprint of the service ?"
+        choices = ["low", "medium", "high", "specific"]
+        default = "low"
+        help = "low <= 20Mb per pool. medium between 20Mb and 40Mb per pool. high > 40Mb per pool.<br>Use specific to set a value with the following option."
+
+        [main.php_fpm_config.free_footprint]
+        ask = "Memory footprint of the service ?"
+        type = "number"
+        default = "0"
+        help = "Free field to specify exactly the footprint in Mb if you don't want to use one of the three previous values."
+
+        [main.php_fpm_config.usage]
+        ask = "Expected usage of the service ?"
+        choices = ["low", "medium", "high"]
+        default = "low"
+        help = "low: Personal usage, behind the sso. No RAM footprint when not used, but the impact on the processor can be high if many users are using the service.<br>medium: Low usage, few people or/and publicly accessible. Low RAM footprint, medium processor footprint when used.<br>high: High usage, frequently visited website. High RAM footprint, but lower on processor usage and quickly responding."

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -340,6 +340,234 @@ ynh_smart_mktemp () {
 }
 
 #=================================================
+
+# Check the amount of available RAM
+#
+# usage: ynh_check_ram [--required=RAM required in Mb] [--no_swap|--only_swap] [--free_ram]
+# | arg: -r, --required= - Amount of RAM required in Mb. The helper will return 0 is there's enough RAM, or 1 otherwise.
+# If --required isn't set, the helper will print the amount of RAM, in Mb.
+# | arg: -s, --no_swap   - Ignore swap
+# | arg: -o, --only_swap - Ignore real RAM, consider only swap.
+# | arg: -f, --free_ram  - Count only free RAM, not the total amount of RAM available.
+ynh_check_ram () {
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [r]=required= [s]=no_swap [o]=only_swap [f]=free_ram )
+	local required
+	local no_swap
+	local only_swap
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+	required=${required:-}
+	no_swap=${no_swap:-0}
+	only_swap=${only_swap:-0}
+
+	local total_ram=$(vmstat --stats --unit M | grep "total memory" | awk '{print $1}')
+	local total_swap=$(vmstat --stats --unit M | grep "total swap" | awk '{print $1}')
+	local total_ram_swap=$(( total_ram + total_swap ))
+
+	local free_ram=$(vmstat --stats --unit M | grep "free memory" | awk '{print $1}')
+	local free_swap=$(vmstat --stats --unit M | grep "free swap" | awk '{print $1}')
+	local free_ram_swap=$(( free_ram + free_swap ))
+
+	# Use the total amount of ram
+	local ram=$total_ram_swap
+	if [ $free_ram -eq 1 ]
+	then
+		# Use the total amount of free ram
+		ram=$free_ram_swap
+		if [ $no_swap -eq 1 ]
+		then
+			# Use only the amount of free ram
+			ram=$free_ram
+		elif [ $only_swap -eq 1 ]
+		then
+			# Use only the amount of free swap
+			ram=$free_swap
+		fi
+	else
+		if [ $no_swap -eq 1 ]
+		then
+			# Use only the amount of free ram
+			ram=$total_ram
+		elif [ $only_swap -eq 1 ]
+		then
+			# Use only the amount of free swap
+			ram=$total_swap
+		fi
+	fi
+
+	if [ -n "$required" ]
+	then
+		# Return 1 if the amount of ram isn't enough.
+		if [ $ram -lt $required ]
+		then
+			return 1
+		else
+			return 0
+		fi
+
+	# If no RAM is required, return the amount of available ram.
+	else
+		echo $ram
+	fi
+}
+
+#=================================================
+
+# Define the values to configure php-fpm
+#
+# usage: ynh_get_scalable_phpfpm --usage=usage --footprint=footprint [--print]
+# | arg: -f, --footprint      - Memory footprint of the service (low/medium/high).
+# low    - Less than 20Mb of ram by pool.
+# medium - Between 20Mb and 40Mb of ram by pool.
+# high   - More than 40Mb of ram by pool.
+# Or specify exactly the footprint, the load of the service as Mb by pool instead of having a standard value.
+# To have this value, use the following command and stress the service.
+# watch -n0.5 ps -o user,cmd,%cpu,rss -u APP
+#
+# | arg: -u, --usage     - Expected usage of the service (low/medium/high).
+# low    - Personal usage, behind the sso.
+# medium - Low usage, few people or/and publicly accessible.
+# high   - High usage, frequently visited website.
+#
+# | arg: -p, --print - Print the result
+#
+#
+#
+# The footprint of the service will be used to defined the maximum footprint we can allow, which is half the maximum RAM.
+# So it will be used to defined 'pm.max_children'
+# A lower value for the footprint will allow more children for 'pm.max_children'. And so for
+#    'pm.start_servers', 'pm.min_spare_servers' and 'pm.max_spare_servers' which are defined from the
+#    value of 'pm.max_children'
+# NOTE: 'pm.max_children' can't exceed 4 times the number of processor's cores.
+#
+# The usage value will defined the way php will handle the children for the pool.
+# A value set as 'low' will set the process manager to 'ondemand'. Children will start only if the
+#   service is used, otherwise no child will stay alive. This config gives the lower footprint when the
+#   service is idle. But will use more proc since it has to start a child as soon it's used.
+# Set as 'medium', the process manager will be at dynamic. If the service is idle, a number of children
+#   equal to pm.min_spare_servers will stay alive. So the service can be quick to answer to any request.
+#   The number of children can grow if needed. The footprint can stay low if the service is idle, but
+#   not null. The impact on the proc is a little bit less than 'ondemand' as there's always a few
+#   children already available.
+# Set as 'high', the process manager will be set at 'static'. There will be always as many children as
+#   'pm.max_children', the footprint is important (but will be set as maximum a quarter of the maximum
+#   RAM) but the impact on the proc is lower. The service will be quick to answer as there's always many
+#   children ready to answer.
+ynh_get_scalable_phpfpm () {
+    local legacy_args=ufp
+    # Declare an array to define the options of this helper.
+    declare -Ar args_array=( [u]=usage= [f]=footprint= [p]=print )
+    local usage
+    local footprint
+    local print
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+    # Set all characters as lowercase
+    footprint=${footprint,,}
+    usage=${usage,,}
+    print=${print:-0}
+
+    if [ "$footprint" = "low" ]
+    then
+        footprint=20
+    elif [ "$footprint" = "medium" ]
+    then
+        footprint=35
+    elif [ "$footprint" = "high" ]
+    then
+        footprint=50
+    fi
+
+    # Define the way the process manager handle child processes.
+    if [ "$usage" = "low" ]
+    then
+        php_pm=ondemand
+    elif [ "$usage" = "medium" ]
+    then
+        php_pm=dynamic
+    elif [ "$usage" = "high" ]
+    then
+        php_pm=static
+    else
+        ynh_die --message="Does not recognize '$usage' as an usage value."
+    fi
+
+    # Get the total of RAM available, except swap.
+    local max_ram=$(ynh_check_ram --no_swap)
+
+    less0() {
+        # Do not allow value below 1
+        if [ $1 -le 0 ]
+        then
+            echo 1
+        else
+            echo $1
+        fi
+    }
+
+    # Define pm.max_children
+    # The value of pm.max_children is the total amount of ram divide by 2 and divide again by the footprint of a pool for this app.
+    # So if php-fpm start the maximum of children, it won't exceed half of the ram.
+    php_max_children=$(( $max_ram / 2 / $footprint ))
+    # If process manager is set as static, use half less children.
+    # Used as static, there's always as many children as the value of pm.max_children
+    if [ "$php_pm" = "static" ]
+    then
+        php_max_children=$(( $php_max_children / 2 ))
+    fi
+    php_max_children=$(less0 $php_max_children)
+
+    # To not overload the proc, limit the number of children to 4 times the number of cores.
+    local core_number=$(nproc)
+    local max_proc=$(( $core_number * 4 ))
+    if [ $php_max_children -gt $max_proc ]
+    then
+        php_max_children=$max_proc
+    fi
+
+    if [ "$php_pm" = "dynamic" ]
+    then
+        # Define pm.start_servers, pm.min_spare_servers and pm.max_spare_servers for a dynamic process manager
+        php_min_spare_servers=$(( $php_max_children / 8 ))
+        php_min_spare_servers=$(less0 $php_min_spare_servers)
+
+        php_max_spare_servers=$(( $php_max_children / 2 ))
+        php_max_spare_servers=$(less0 $php_max_spare_servers)
+
+        php_start_servers=$(( $php_min_spare_servers + ( $php_max_spare_servers - $php_min_spare_servers ) /2 ))
+        php_start_servers=$(less0 $php_start_servers)
+    else
+        php_min_spare_servers=0
+        php_max_spare_servers=0
+        php_start_servers=0
+    fi
+
+    if [ $print -eq 1 ]
+    then
+        ynh_debug --message="Footprint=${footprint}Mb by pool."
+        ynh_debug --message="Process manager=$php_pm"
+        ynh_debug --message="Max RAM=${max_ram}Mb"
+        if [ "$php_pm" != "static" ]; then
+            ynh_debug --message="\nMax estimated footprint=$(( $php_max_children * $footprint ))"
+            ynh_debug --message="Min estimated footprint=$(( $php_min_spare_servers * $footprint ))"
+        fi
+        if [ "$php_pm" = "dynamic" ]; then
+            ynh_debug --message="Estimated average footprint=$(( $php_max_spare_servers * $footprint ))"
+        elif [ "$php_pm" = "static" ]; then
+            ynh_debug --message="Estimated footprint=$(( $php_max_children * $footprint ))"
+        fi
+        ynh_debug --message="\nRaw php-fpm values:"
+        ynh_debug --message="pm.max_children = $php_max_children"
+        if [ "$php_pm" = "dynamic" ]; then
+            ynh_debug --message="pm.start_servers = $php_start_servers"
+            ynh_debug --message="pm.min_spare_servers = $php_min_spare_servers"
+            ynh_debug --message="pm.max_spare_servers = $php_max_spare_servers"
+        fi
+    fi
+}
+
+#=================================================
 # FUTURE OFFICIAL HELPERS
 #=================================================
 

--- a/scripts/_ynh_add_fpm_config
+++ b/scripts/_ynh_add_fpm_config
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# Create a dedicated php-fpm config
+#
+# usage 1: ynh_add_fpm_config [--phpversion=7.X] [--use_template]
+# | arg: -v, --phpversion - Version of php to use.
+# | arg: -t, --use_template - Use this helper in template mode.
+#
+# -----------------------------------------------------------------------------
+#
+# usage 2: ynh_add_fpm_config [--phpversion=7.X] --usage=usage --footprint=footprint
+# | arg: -v, --phpversion - Version of php to use.#
+# | arg: -f, --footprint      - Memory footprint of the service (low/medium/high).
+# low    - Less than 20Mb of ram by pool.
+# medium - Between 20Mb and 40Mb of ram by pool.
+# high   - More than 40Mb of ram by pool.
+# Or specify exactly the footprint, the load of the service as Mb by pool instead of having a standard value.
+# To have this value, use the following command and stress the service.
+# watch -n0.5 ps -o user,cmd,%cpu,rss -u APP
+#
+# | arg: -u, --usage     - Expected usage of the service (low/medium/high).
+# low    - Personal usage, behind the sso.
+# medium - Low usage, few people or/and publicly accessible.
+# high   - High usage, frequently visited website.
+#
+# Requires YunoHost version 2.7.2 or higher.
+ynh_add_fpm_config () {
+	# Declare an array to define the options of this helper.
+	local legacy_args=vtuf
+	declare -Ar args_array=( [v]=phpversion= [t]=use_template [u]=usage= [f]=footprint= )
+	local phpversion
+    local use_template
+    local usage
+    local footprint
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+	# The default behaviour is to use the template.
+    use_template="${use_template:-1}"
+    usage="${usage:-}"
+    footprint="${footprint:-}"
+    if [ -n "$usage" ] || [ -n "$footprint" ]; then
+        use_template=0
+    fi
+
+	# Configure PHP-FPM 7.0 by default
+	phpversion="${phpversion:-7.0}"
+
+	local fpm_config_dir="/etc/php/$phpversion/fpm"
+	local fpm_service="php${phpversion}-fpm"
+	# Configure PHP-FPM 5 on Debian Jessie
+	if [ "$(ynh_get_debian_release)" == "jessie" ]; then
+		fpm_config_dir="/etc/php5/fpm"
+		fpm_service="php5-fpm"
+	fi
+	ynh_app_setting_set --app=$app --key=fpm_config_dir --value="$fpm_config_dir"
+	ynh_app_setting_set --app=$app --key=fpm_service --value="$fpm_service"
+	finalphpconf="$fpm_config_dir/pool.d/$app.conf"
+	ynh_backup_if_checksum_is_different --file="$finalphpconf"
+
+	if [ $use_template -eq 1 ]
+	then
+        # Usage 1, use the template in ../conf/php-fpm.conf
+        sudo cp ../conf/php-fpm.conf "$finalphpconf"
+        ynh_replace_string --match_string="__NAMETOCHANGE__" --replace_string="$app" --target_file="$finalphpconf"
+        ynh_replace_string --match_string="__FINALPATH__" --replace_string="$final_path" --target_file="$finalphpconf"
+        ynh_replace_string --match_string="__USER__" --replace_string="$app" --target_file="$finalphpconf"
+        ynh_replace_string --match_string="__PHPVERSION__" --replace_string="$phpversion" --target_file="$finalphpconf"
+
+	else
+        # Usage 2, generate a php-fpm config file with ynh_get_scalable_phpfpm
+        ynh_get_scalable_phpfpm --usage=$usage --footprint=$footprint
+
+        # Copy the default file
+        sudo cp "$fpm_config_dir/pool.d/www.conf" "$finalphpconf"
+
+        # Replace standard variables into the default file
+        ynh_replace_string --match_string="^\[www\]" --replace_string="[$app]" --target_file="$finalphpconf"
+        ynh_replace_string --match_string=".*listen = .*" --replace_string="listen = /var/run/php/php7.0-fpm-$app.sock" --target_file="$finalphpconf"
+        ynh_replace_string --match_string="^user = .*" --replace_string="user = $app" --target_file="$finalphpconf"
+        ynh_replace_string --match_string="^group = .*" --replace_string="group = $app" --target_file="$finalphpconf"
+        ynh_replace_string --match_string=".*chdir = .*" --replace_string="chdir = $final_path" --target_file="$finalphpconf"
+
+        # Configure fpm children
+        ynh_replace_string --match_string=".*pm = .*" --replace_string="pm = $php_pm" --target_file="$finalphpconf"
+        ynh_replace_string --match_string=".*pm.max_children = .*" --replace_string="pm.max_children = $php_max_children" --target_file="$finalphpconf"
+        ynh_replace_string --match_string=".*pm.max_requests = .*" --replace_string="pm.max_requests = 500" --target_file="$finalphpconf"
+        ynh_replace_string --match_string=".*request_terminate_timeout = .*" --replace_string="request_terminate_timeout = 1d" --target_file="$finalphpconf"
+        if [ "$php_pm" = "dynamic" ]
+        then
+            ynh_replace_string --match_string=".*pm.start_servers = .*" --replace_string="pm.start_servers = $php_start_servers" --target_file="$finalphpconf"
+            ynh_replace_string --match_string=".*pm.min_spare_servers = .*" --replace_string="pm.min_spare_servers = $php_min_spare_servers" --target_file="$finalphpconf"
+            ynh_replace_string --match_string=".*pm.max_spare_servers = .*" --replace_string="pm.max_spare_servers = $php_max_spare_servers" --target_file="$finalphpconf"
+        elif [ "$php_pm" = "ondemand" ]
+        then
+            ynh_replace_string --match_string=".*pm.process_idle_timeout = .*" --replace_string="pm.process_idle_timeout = 10s" --target_file="$finalphpconf"
+        fi
+
+        # Comment unused parameters
+        if [ "$php_pm" != "dynamic" ]
+        then
+            ynh_replace_string --match_string=".*\(pm.start_servers = .*\)" --replace_string=";\1" --target_file="$finalphpconf"
+            ynh_replace_string --match_string=".*\(pm.min_spare_servers = .*\)" --replace_string=";\1" --target_file="$finalphpconf"
+            ynh_replace_string --match_string=".*\(pm.max_spare_servers = .*\)" --replace_string=";\1" --target_file="$finalphpconf"
+        fi
+        if [ "$php_pm" != "ondemand" ]
+        then
+            ynh_replace_string --match_string=".*\(pm.process_idle_timeout = .*\)" --replace_string=";\1" --target_file="$finalphpconf"
+        fi
+
+        # Concatene the extra config.
+        if [ -e ../conf/extra_php-fpm.conf ]; then
+            cat ../conf/extra_php-fpm.conf >> "$finalphpconf"
+        fi
+	fi
+	sudo chown root: "$finalphpconf"
+	ynh_store_file_checksum --file="$finalphpconf"
+
+	if [ -e "../conf/php-fpm.ini" ]
+	then
+		echo "Packagers ! Please do not use a separate php ini file, merge your directives in the pool file instead." >&2
+		finalphpini="$fpm_config_dir/conf.d/20-$app.ini"
+		ynh_backup_if_checksum_is_different "$finalphpini"
+		sudo cp ../conf/php-fpm.ini "$finalphpini"
+		sudo chown root: "$finalphpini"
+		ynh_store_file_checksum "$finalphpini"
+	fi
+	ynh_systemd_action --service_name=$fpm_service --action=reload
+}

--- a/scripts/config
+++ b/scripts/config
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+#=================================================
+# GENERIC STARTING
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
+
+source _common.sh
+source /usr/share/yunohost/helpers
+source _ynh_add_fpm_config
+
+#=================================================
+# RETRIEVE ARGUMENTS
+#=================================================
+
+app=${YNH_APP_INSTANCE_NAME:-$YNH_APP_ID}
+
+#=================================================
+# LOAD VALUES
+#=================================================
+
+# Load the real value from the app config or elsewhere.
+# Then get the value from the form.
+# If the form has a value for a variable, take the value from the form,
+# Otherwise, keep the value from the app config.
+
+# Footprint for php-fpm
+old_fpm_footprint="$(ynh_app_setting_get --app=$app --key=fpm_footprint)"
+fpm_footprint="${YNH_CONFIG_MAIN_PHP_FPM_CONFIG_FOOTPRINT:-$old_fpm_footprint}"
+
+# Free footprint value for php-fpm
+# Check if fpm_footprint is an integer
+if [ "$fpm_footprint" -eq "$fpm_footprint" ] 2> /dev/null
+then
+    # If fpm_footprint is an integer, that's a numeric value for the footprint
+    old_free_footprint=$fpm_footprint
+    fpm_footprint=specific
+else
+    old_free_footprint=0
+fi
+free_footprint="${YNH_CONFIG_MAIN_PHP_FPM_CONFIG_FREE_FOOTPRINT:-$old_free_footprint}"
+
+# Usage for php-fpm
+old_fpm_usage="$(ynh_app_setting_get --app=$app --key=fpm_usage)"
+fpm_usage="${YNH_CONFIG_MAIN_PHP_FPM_CONFIG_USAGE:-$old_fpm_usage}"
+
+#=================================================
+# SHOW_CONFIG FUNCTION FOR 'SHOW' COMMAND
+#=================================================
+
+show_config() {
+	# here you are supposed to read some config file/database/other then print the values
+	# ynh_return "YNH_CONFIG_${PANEL_ID}_${SECTION_ID}_${OPTION_ID}=value"
+
+	ynh_return "YNH_CONFIG_MAIN_PHP_FPM_CONFIG_FOOTPRINT=$fpm_footprint"
+	ynh_return "YNH_CONFIG_MAIN_PHP_FPM_CONFIG_FREE_FOOTPRINT=$free_footprint"
+	ynh_return "YNH_CONFIG_MAIN_PHP_FPM_CONFIG_USAGE=$fpm_usage"
+}
+
+#=================================================
+# MODIFY THE CONFIGURATION
+#=================================================
+
+apply_config() {
+
+    #=================================================
+    # RECONFIGURE PHP-FPM
+    #=================================================
+
+    if [ "$fpm_usage" != "$old_fpm_usage" ] || [ "$fpm_footprint" != "$old_fpm_footprint" ] || [ "$free_footprint" != "$old_free_footprint" ]
+    then
+        # If fpm_footprint is set to 'specific', use $free_footprint value.
+        if [ "$fpm_footprint" = "specific" ]
+        then
+            fpm_footprint=$free_footprint
+        fi
+
+        if [ "$fpm_footprint" != "0" ]
+        then
+            ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint
+        else
+            ynh_print_err --message="When selecting 'specific', you have to set a footprint value into the field below."
+        fi
+    fi
+}
+
+#=================================================
+# GENERIC FINALIZATION
+#=================================================
+# SELECT THE ACTION FOLLOWING THE GIVEN ARGUMENT
+#=================================================
+
+case $1 in
+  show) show_config;;
+  apply) apply_config;;
+esac

--- a/scripts/install
+++ b/scripts/install
@@ -8,6 +8,7 @@
 
 source _common.sh
 source /usr/share/yunohost/helpers
+source _ynh_add_fpm_config
 
 #=================================================
 # MANAGE SCRIPT FAILURE
@@ -115,7 +116,7 @@ ynh_system_user_create --username=$app
 ynh_script_progression --message="Configuring php-fpm..." --weight=2
 
 # Create a dedicated php-fpm config
-ynh_add_fpm_config
+ynh_add_fpm_config --usage=medium --footprint=high
 
 #=================================================
 # SPECIFIC SETUP

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -8,6 +8,7 @@
 
 source _common.sh
 source /usr/share/yunohost/helpers
+source _ynh_add_fpm_config
 
 #=================================================
 # LOAD SETTINGS
@@ -22,6 +23,9 @@ admin=$(ynh_app_setting_get --app=$app --key=admin)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 user_home=$(ynh_app_setting_get --app=$app --key=user_home)
+
+fpm_footprint=$(ynh_app_setting_get --app=$app --key=fpm_footprint)
+fpm_usage=$(ynh_app_setting_get --app=$app --key=fpm_usage)
 
 #=================================================
 # CHECK VERSION
@@ -48,6 +52,18 @@ fi
 
 # Remove the option backup_core_only if it's in the settings.yml file
 ynh_app_setting_delete --app=$app --key=backup_core_only
+
+# If fpm_footprint doesn't exist, create it
+if [ -z "$fpm_footprint" ]; then
+	fpm_footprint=high
+	ynh_app_setting_set --app=$app --key=fpm_footprint --value=$fpm_footprint
+fi
+
+# If fpm_usage doesn't exist, create it
+if [ -z "$fpm_usage" ]; then
+	fpm_usage=medium
+	ynh_app_setting_set --app=$app --key=fpm_usage --value=$fpm_usage
+fi
 
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
@@ -155,7 +171,7 @@ ynh_system_user_create --username=$app
 ynh_script_progression --message="Upgrading php-fpm configuration..." --weight=2
 
 # Create a dedicated php-fpm config
-ynh_add_fpm_config
+ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint
 
 # Delete existing ini configuration file (backward compatibility)
 if [ -f /etc/php/7.0/fpm/conf.d/20-$app.ini ]; then


### PR DESCRIPTION
Replace #176

## Problem
- *As stated by metalux on the chat room, nextcloud will crash a Raspberry Pi if it needs a lot of ram.
That's because php will spawn too much process to handle the request.*

## Solution
- ~*`memory_limit` wasn't of any help, since it overload the CPU instead of the ram...
So, let's limit to 3 processes instead of 10.*~
- Use ynh_get_scalable_phpfpm to adapt php to the actual device.

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested. Crashed a raspi to do it !!! Sorry metalux :D
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR247/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR247/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.