### PR TITLE
[fix] Report an old fix (PATH warning)

### DIFF
--- a/conf/extra_php-fpm.conf
+++ b/conf/extra_php-fpm.conf
@@ -1,4 +1,5 @@
-
+; Report an old fix (PATH warning)
+env[PATH] = $PATH
 ; Additional php.ini defines, specific to this pool of workers.
 php_value[upload_max_filesize] = 10G
 php_value[post_max_size] = 10G


### PR DESCRIPTION
## Problem
- *This path warning has reappeared after adding `ynh_get_scalable_phpfpm` during last update :* `PHP does not appear to be properly set up to query system environment variables. The test with getenv ( "PATH") returns only an empty response.`

## Solution
- *Apply old [fix](https://github.com/YunoHost-Apps/nextcloud_ynh/pull/188/commits/779173d6c4fb229d7cb0590be6a5f08c2f55c560 ) proposed by [JimboJoe](https://github.com/JimboJoe) : add `env[PATH] = $PATH` into ` conf/extra_php-fpm.conf`*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
