### PR TITLE
[fix] Precise php version

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,7 +3,7 @@
 # COMMON VARIABLES
 #=================================================
 
-pkg_dependencies="php-gd php-json php-intl php-mcrypt php-curl php-apcu php-redis php-ldap php-imagick php-zip php-mbstring php-xml imagemagick acl tar smbclient at"
+pkg_dependencies="php7.0-gd php7.0-json php7.0-intl php7.0-mcrypt php7.0-curl php7.0-apcu php7.0-redis php7.0-ldap php7.0-imagick php7.0-zip php7.0-mbstring php7.0-xml imagemagick acl tar smbclient at"
 
 #=================================================
 # EXPERIMENTAL HELPERS


### PR DESCRIPTION


## Problem
to avoid conflict with other package installing sury and php7.x > 0

## Solution
Specify the version in package name

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
