### PR TITLE
[buster] No php-mcrypt anymoar

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,7 +3,7 @@
 # COMMON VARIABLES
 #=================================================
 
-pkg_dependencies="php-gd php-json php-intl php-mcrypt php-curl php-apcu php-redis php-ldap php-imagick php-zip php-mbstring php-xml imagemagick acl tar smbclient at"
+pkg_dependencies="php-gd php-json php-intl php-curl php-apcu php-redis php-ldap php-imagick php-zip php-mbstring php-xml imagemagick acl tar smbclient at"
 
 #=================================================
 # EXPERIMENTAL HELPERS


### PR DESCRIPTION
## Problem

Install fails on buster because there's no php-mcrypt anymore

## Solution

After a quick lookup on the internet, my understanding is that the stuff provided by php-mcrypt is old / deprecated since a while, and in fact Nextcloud doesnt need it anymore (it was added back to the jessie or maybe even squeeze era).

So let's remove it. (N.B. : I haven't tested anything though - but it should be okay to commit this for stretch as well)

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [X] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR259/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR259/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
