### PR TITLE
Don't use parentheses

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -292,7 +292,7 @@ then
         # Upgrade Nextcloud (SUCCESS = 0, UP_TO_DATE = 3)
         exec_occ maintenance:mode --off
         exec_occ upgrade \
-        || ([ $? -eq 3 ] || ynh_die --message="Unable to upgrade Nextcloud")
+        || [ $? -eq 3 ] || ynh_die --message="Unable to upgrade Nextcloud"
 
         # Get the new current version number
         current_version=$(grep OC_VersionString "$final_path/version.php" | cut -d\' -f2)


### PR DESCRIPTION
## Problem
- *Parentheses are useless here (I guess?)*
- *Parentheses create a subshell, and ynh_die exit only the subshell, not the main script*

## Solution
- *Remove parentheses*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR264/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR264/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
