### PR TITLE
Add an action to disable maintenance mode

### DIFF
--- a/actions.toml
+++ b/actions.toml
@@ -1,0 +1,8 @@
+[disable_maintenance]
+name = "Disable the maintenance mode of Nextcloud"
+command = "/bin/bash scripts/actions/disable_maintenance"
+# user = "root"  # optional
+# cwd = "/" # optional
+# accepted_return_codes = [0, 1, 2, 3]  # optional
+accepted_return_codes = [0]
+description = "Disable the maintenance mode of Nextcloud if you're stuck after an upgrade"

--- a/scripts/actions/disable_maintenance
+++ b/scripts/actions/disable_maintenance
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+#=================================================
+# GENERIC STARTING
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
+
+source scripts/_common.sh
+source /usr/share/yunohost/helpers
+
+#=================================================
+# RETRIEVE ARGUMENTS
+#=================================================
+
+app=${YNH_APP_INSTANCE_NAME:-$YNH_APP_ID}
+
+final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+
+#=================================================
+# CHECK IF ARGUMENTS ARE CORRECT
+#=================================================
+
+#=================================================
+# CHECK IF AN ACTION HAS TO BE DONE
+#=================================================
+
+# Check the current status of the maintenance mode
+
+if [ "$(grep "maintenance" "$final_path/config/config.php" | awk '{print $3}' | cut -d',' -f1)" != "true" ]
+then
+    ynh_die --message="Nextcloud isn't currently under maintenance." --ret_code=0
+fi
+
+#=================================================
+# SPECIFIC ACTION
+#=================================================
+# DISABLE THE MAINTENANCE MODE
+#=================================================
+
+ynh_script_progression --message="Disabling maintenance mode..." --weight=3
+
+(
+cd "$final_path" && exec_as "$app" \
+    php$YNH_PHP_VERSION occ --no-interaction --no-ansi maintenance:mode --off
+)
+
+#=================================================
+# END OF SCRIPT
+#=================================================
+
+ynh_script_progression --message="Execution completed" --last


### PR DESCRIPTION
## Problem
- *Many users get stuck in maintenance mode, and have to go to ssh to fix it*

## Solution
- *Users shouldn't have to use ssh to fix that.*
- *Add an action to remove the maintenance mode from the admin panel.*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR271/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR271/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.