### PR TITLE
Add documentation link + how to use occ command + OnlyOffice tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ If you need/want to use Nextcloud `occ` command¹, you need to be in `/var/www/n
 
 *NB: You may need to adapt `php7.3` to the PHP version that Nextcloud is using. Starting from Nextcloud 18, YunoHost uses php7.3, it used before php7.0.*
 
-¹ See https://docs.nextcloud.com/server/18/admin_manual/configuration_server/occ_command.html. Use this only if you know what you're doing :)
+¹ See https://docs.nextcloud.com/server/18/admin_manual/configuration_server/occ_command.html
+ Use this only if you know what you're doing :)
 
 #### Migrate from ownCloud
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To install and configure it:
 - You can also configure with file formats should be openned by OnlyOffice.
 - Here you go :) You should be able to create new type of documents and open them.
 
+*NB: OnlyOffice is only available for x86 architecture - **ARM** (Raspberry Pi, …) is **not** supported*
 
 ## YunoHost specific features
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,22 @@ you can synchronize your files over your devices.
 * [YunoHost demo](https://demo.yunohost.org/nextcloud/)
 * [Official demo](https://demo.nextcloud.com/)
 
-## Configuration
-
 ## Documentation
 
  * Official documentation: https://docs.nextcloud.com/server/18/user_manual/
  * YunoHost documentation: https://github.com/YunoHost/doc/blob/master/app_nextcloud_fr.md
+
+## Configuration
+
+#### Configure OnlyOffice integration
+
+Starting from Nextcloud 18, it features a direct integration of OnlyOffice (an online rich text document editor) thought a Nextcloud app.
+To install and configure it:
+- Install *Community Document Server* application in your Nextcloud
+- Then in Settings -> OnlyOffice (`https://yourdomain.tld/nextcloud/settings/admin/onlyoffice`), you need to configure its URL with `https://yourdomain.tld/nextcloud/index.php/apps/documentserver_community/`. Keep others server parameters empty. Save it.
+- You can also configure with file formats should be openned by OnlyOffice.
+- Here you go :) You should be able to create new type of documents and open them.
+
 
 ## YunoHost specific features
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Following symlinks is not allowed ('/home/yunohost.multimedia/user/Share' -> '/h
 
 If you need/want to use Nextcloud `occ` command¹, you need to be in `/var/www/nextcloud/` folder, then use `sudo -u nextcloud php7.3 occ` instead of `occ` (as an alternative, you can use `/var/www/nextcloud/occ` to run the command from another directory).
 
-*NB: you may need to adapt `php7.3` to the php version that Nextcloud is using. Since Nextcloud 18 Yunohost use php7.3, before it was php7.0.*
+*NB: You may need to adapt `php7.3` to the PHP version that Nextcloud is using. Starting from Nextcloud 18, YunoHost uses php7.3, it used before php7.0.*
 
 ¹ See https://docs.nextcloud.com/server/18/admin_manual/configuration_server/occ_command.html. Use this only if you know what you're doing :)
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Starting from Nextcloud 18, it features a direct integration of OnlyOffice (an o
 To install and configure it:
 - Install *Community Document Server* application in your Nextcloud. That's the part that runs OnlyOffice server.
 - Install OnlyOffice application. That's the client part that will connect to an OnlyOffice server.
-- Then in Settings -> OnlyOffice (`https://yourdomain.tld/nextcloud/settings/admin/onlyoffice`), you need to configure its URL with `https://yourdomain.tld/nextcloud/index.php/apps/documentserver_community/` (an URL might be defined by default, but is not always correct). Keep others server parameters empty. Save it.
+- Then in Settings -> OnlyOffice (`https://yourdomain.tld/nextcloud/settings/admin/onlyoffice`), you need to configure its URL with `https://yourdomain.tld/nextcloud/index.php/apps/documentserver_community/` (an URL might be defined by default, but is not always correct). Please note the **`/index.php/`**. Keep others server parameters empty. Save it.
 - You can also configure which file formats should be opened by OnlyOffice.
 - Here you go :) You should be able to create new type of documents and open them.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Following symlinks is not allowed ('/home/yunohost.multimedia/user/Share' -> '/h
 
 ## Additionnal informations
 
+#### `occ` command usage
+
+If you need/want to use Nextcloud `occ` command¹, you need to be in `/var/www/nextcloud/` folder, then use `sudo -u nextcloud php7.3 occ` instead of `occ` (as an alternative, you can use `/var/www/nextcloud/occ` to run the command from another directory).
+
+*NB: you may need to adapt `php7.3` to the php version that Nextcloud is using. Since Nextcloud 18 Yunohost use php7.3, before it was php7.0.*
+
+¹ See https://docs.nextcloud.com/server/18/admin_manual/configuration_server/occ_command.html. Use this only if you know what you're doing :)
+
 #### Migrate from ownCloud
 
 **This is not considered as stable yet, please do it with care and only for
@@ -104,6 +112,7 @@ sudo yunohost app ssowatconf
 
  * Report a bug: https://github.com/YunoHost-Apps/nextcloud_ynh/issues
  * Nextcloud website: https://nextcloud.com/
+ * Nextcloud documentation:  https://docs.nextcloud.com/
  * Nextcloud repository: https://github.com/nextcloud/server
  * YunoHost website: https://yunohost.org/
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ you can synchronize your files over your devices.
 
 #### Configure OnlyOffice integration
 
-Starting from Nextcloud 18, it features a direct integration of OnlyOffice (an online rich text document editor) thought a Nextcloud app.
+Starting from Nextcloud 18, it features a direct integration of OnlyOffice (an online rich text document editor) through a Nextcloud app.
 To install and configure it:
 - Install *Community Document Server* application in your Nextcloud. That's the part that runs OnlyOffice server.
 - Install OnlyOffice application. That's the client part that will connect to an OnlyOffice server.
 - Then in Settings -> OnlyOffice (`https://yourdomain.tld/nextcloud/settings/admin/onlyoffice`), you need to configure its URL with `https://yourdomain.tld/nextcloud/index.php/apps/documentserver_community/` (an URL might be defined by default, but is not always correct). Keep others server parameters empty. Save it.
-- You can also configure with file formats should be openned by OnlyOffice.
+- You can also configure which file formats should be opened by OnlyOffice.
 - Here you go :) You should be able to create new type of documents and open them.
 
 *NB: OnlyOffice is only available for x86 architecture - **ARM** (Raspberry Pi, …) is **not** supported*
@@ -125,7 +125,6 @@ sudo yunohost app ssowatconf
 
  * Report a bug: https://github.com/YunoHost-Apps/nextcloud_ynh/issues
  * Nextcloud website: https://nextcloud.com/
- * Nextcloud documentation:  https://docs.nextcloud.com/
  * Nextcloud repository: https://github.com/nextcloud/server
  * YunoHost website: https://yunohost.org/
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ you can synchronize your files over your devices.
 
 Starting from Nextcloud 18, it features a direct integration of OnlyOffice (an online rich text document editor) thought a Nextcloud app.
 To install and configure it:
-- Install *Community Document Server* application in your Nextcloud
-- Then in Settings -> OnlyOffice (`https://yourdomain.tld/nextcloud/settings/admin/onlyoffice`), you need to configure its URL with `https://yourdomain.tld/nextcloud/index.php/apps/documentserver_community/`. Keep others server parameters empty. Save it.
+- Install *Community Document Server* application in your Nextcloud. That's the part that runs OnlyOffice server.
+- Install OnlyOffice application. That's the client part that will connect to an OnlyOffice server.
+- Then in Settings -> OnlyOffice (`https://yourdomain.tld/nextcloud/settings/admin/onlyoffice`), you need to configure its URL with `https://yourdomain.tld/nextcloud/index.php/apps/documentserver_community/` (an URL might be defined by default, but is not always correct). Keep others server parameters empty. Save it.
 - You can also configure with file formats should be openned by OnlyOffice.
 - Here you go :) You should be able to create new type of documents and open them.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Following symlinks is not allowed ('/home/yunohost.multimedia/user/Share' -> '/h
 
 #### `occ` command usage
 
-If you need/want to use Nextcloud `occ` command¹, you need to be in `/var/www/nextcloud/` folder, then use `sudo -u nextcloud php7.3 occ` instead of `occ` (as an alternative, you can use `/var/www/nextcloud/occ` to run the command from another directory).
+If you need/want to use Nextcloud `occ` command¹, you need to be in `/var/www/nextcloud/` folder (or `/var/www/nextcloud__n/` depending on your instance number in case of multiple concurrent installations), then use `sudo -u nextcloud php7.3 occ` instead of `occ` (as an alternative, you can use `/var/www/nextcloud/occ` to run the command from another directory).
 
 *NB: You may need to adapt `php7.3` to the PHP version that Nextcloud is using. Starting from Nextcloud 18, YunoHost uses php7.3, it used before php7.0.*
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ you can synchronize your files over your devices.
 ## Documentation
 
  * Official documentation: https://docs.nextcloud.com/server/18/user_manual/
- * YunoHost documentation: https://github.com/YunoHost/doc/blob/master/app_nextcloud_fr.md
+ * YunoHost documentation: https://github.com/YunoHost/doc/blob/master/app_nextcloud.md
 
 ## Configuration
 


### PR DESCRIPTION
- Add a link to Nextcloud documentation
- Explain how to use occ command with Yunohost config

## Problem
- People wiling to use `occ` command (for instance when an app update fails, and they are stuck in maintenance mode) might get confused when they try it.
Ex: #277
- There's no link to Nextcloud documentation.

## Solution
- Explain how to use `occ` command
- add a link to the documentation

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
