### PR TITLE
[fix] Backward compatibility for NC 14 or older

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -200,11 +200,11 @@ fi
 # Define a function to execute commands with `occ`
 exec_occ() {
     # Backward compatibility to upgrade from NC14 or older version
-    if [ $current_major_version -gt 14 ]
+    if [ $current_major_version -lt 15 ]
     then
-	NEXTCLOUD_PHP_VERSION=$YNH_PHP_VERSION
-    else
         NEXTCLOUD_PHP_VERSION="7.0"
+    else
+	NEXTCLOUD_PHP_VERSION=$YNH_PHP_VERSION
     fi
 (cd "$final_path" && exec_as "$app" \
     php$NEXTCLOUD_PHP_VERSION occ --no-interaction --no-ansi "$@")

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -199,8 +199,15 @@ fi
 
 # Define a function to execute commands with `occ`
 exec_occ() {
+    # Backward compatibility to upgrade from NC14 or older version
+    if [ $current_major_version -gt 14 ]
+    then
+	NEXTCLOUD_PHP_VERSION=$YNH_PHP_VERSION
+    else
+        NEXTCLOUD_PHP_VERSION="7.0"
+    fi
 (cd "$final_path" && exec_as "$app" \
-    php$YNH_PHP_VERSION occ --no-interaction --no-ansi "$@")
+    php$NEXTCLOUD_PHP_VERSION occ --no-interaction --no-ansi "$@")
 }
 
 # Define a function to add an external storage

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -204,7 +204,7 @@ exec_occ() {
     then
         NEXTCLOUD_PHP_VERSION="7.0"
     else
-	NEXTCLOUD_PHP_VERSION=$YNH_PHP_VERSION
+        NEXTCLOUD_PHP_VERSION=$YNH_PHP_VERSION
     fi
 (cd "$final_path" && exec_as "$app" \
     php$NEXTCLOUD_PHP_VERSION occ --no-interaction --no-ansi "$@")


### PR DESCRIPTION
## Problem
Can't upgrade from nextcloud 13 (and probably 14)

## Solution
Use php7.0 for upgrade these version and next use the new php version

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : Kay0u
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR282/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR282/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
