### PR TITLE
Do not use argon2 to hash password

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -10,7 +10,8 @@
       "port": "6379",
       "timeout": "0.0",
       "password": ""
-     }
+     },
+    "hashing_default_password": true
   },
   "apps": {
     "user_ldap": {


### PR DESCRIPTION
## Problem
- *Argon2, used to hashing password slow down small devices*
- *https://forum.yunohost.org/t/official-app-nextcloud/9223/148*

## Solution
- *According to https://github.com/nextcloud/server/pull/19203, do not use argon2 at all.*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : Kay0u
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR294/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR294/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.