### PR TITLE
Fix "spinning wheel" when no README.md file in folder.

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -57,7 +57,9 @@ location ^~ __PATH__/ {
 
   # Errors pages
   error_page 403 __PATH__/core/templates/403.php;
-  error_page 404 __PATH__/core/templates/404.php;
+  # Don't set custom 404 error page, as nextcloud uses 404 codes with meaningful payload.
+  # Setting custom 404 page clears the payload and creates UI bugs
+  # error_page 404 __PATH__/core/templates/404.php;
 
   location __PATH__/ {
     rewrite ^ __PATH__/index.php;


### PR DESCRIPTION
## Problem
The rich workspace dialouge loads by default in every folder.
When user deletes README.md file, Nextcloud responds with 404 http code
to inform the UI scipts to not render the rich workspace.
Overwriting the response with custom 404 status page creates "spinning wheel" UI bug
in every folder without README.md file in it.

## Solution
Do not overwrite 404 response with blank page ¯\\\_(ツ)\_/¯

Fixes #318

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR319/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR319/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
