### PR TITLE
Disable pretty urls

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -90,7 +90,9 @@ location ^~ __PATH__/ {
     # Avoid sending the security headers twice
     fastcgi_param modHeadersAvailable true;
     # Enable pretty urls
-    fastcgi_param front_controller_active true;
+    # Do not enable pretty urls because it break a lot of apps
+    # To make it works, we must change "alias" into "root", which creates another set of problems.
+    #fastcgi_param front_controller_active true;
     fastcgi_pass unix:/var/run/php/php__YNH_PHP_VERSION__-fpm-__NAME__.sock;
     fastcgi_intercept_errors on;
     fastcgi_request_buffering off;
@@ -99,26 +101,6 @@ location ^~ __PATH__/ {
   location ~ ^__PATH__/(?:updater|oc[ms]-provider)(?:$|\/) {
     try_files $uri/ =404;
     index index.php;
-  }
-
-  location = __PATH__/core/js/oc.js {
-    rewrite ^ __PATH__/index.php$request_uri;
-  }
-
-  location = __PATH__/core/preview.png {
-    rewrite ^ __PATH__/index.php$request_uri;
-  }
-
-  location ~* ^__PATH__/(?:css|js)/ {
-    rewrite ^ __PATH__/index.php$request_uri;
-  }
-
-  location ~* ^__PATH__/apps/theming/img/core/filetypes/ {
-    rewrite ^ __PATH__/index.php$request_uri;
-  }
-
-  location ~* ^__PATH__/apps/documentserver_community/ {
-    rewrite ^ __PATH__/index.php$request_uri;
   }
 
   # Adding the cache control header for js, css and map files


### PR DESCRIPTION
## Problem

The default nginx configuration uses `root` rather than `alias`. This works very well, but from what I understood from my tests there are some limitations:
According to the [doc](https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html):
- For nextcloud installed at the root of a domain, we use `root /var/www/nextcloud;`, everything works with pretty urls.
- For nextcloud installed on a subpath, then we use `root /var/www;` instead. Which is a problem for us because then nextcloud would have to be in the `/var/www/url_path_chosen_by_the_user` directory.

So we have to replace `root` by `alias` (which works very well), but then with pretty urls enabled, many apps don't work anymore, like for example: https://github.com/YunoHost-Apps/nextcloud_ynh/issues/331, `documentserver_community` where we had to add a specific `location`... Anyway, I searched for a long time, and I couldn't find any other solution than to disable it.

We will then have urls of the form:

`https://domain.tld/nextcloud/index.php/apps/....`
instead of
`https://domain.tld/nextcloud/apps/....`

How bad is it?

## Solution
- *Disable pretty urls*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
