### PR TITLE
Fix issues with Element (Riotchat) app

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -121,6 +121,10 @@ location ^~ __PATH__/ {
     rewrite ^ __PATH__/index.php$request_uri;
   }
 
+  location ~* ^__PATH__/apps/riotchat/riot/ {
+    rewrite ^ __PATH__/index.php$request_uri;
+  }
+
   # Adding the cache control header for js, css and map files
   location ~ ^__PATH__/.+[^\/]\.(?:css|js|woff2?|svg|gif|map)$ {
     try_files $uri __PATH__/index.php$request_uri;


### PR DESCRIPTION
## Problem
- See bug #331

## Solution
- Redirect call to riot files using `location...` to use something like `https://domain.tld/nextcloud/index.php/apps/....`
This specific configuration is similar to the conf of `documentserver_community`

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR340/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR340/)
