### PR TITLE
Moar linter warning fixes

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -154,7 +154,7 @@ ynh_handle_app_migration ()  {
 
     # TODO Handle multi instance apps...
     # Check that there is not already an app installed for this id.
-    (yunohost app list --installed -f "$new_app" | grep -q id) \
+    yunohost app list | grep -q 'id: $appname' \
     && ynh_die "$new_app is already installed"
 
     #=================================================
@@ -360,7 +360,7 @@ ynh_multimedia_build_main_dir () {
         local checksum="806a827ba1902d6911095602a9221181"
 
         # Download yunohost.multimedia scripts
-        wget -nv https://github.com/YunoHost-Apps/yunohost.multimedia/archive/${ynh_media_release}.tar.gz
+        wget -nv https://github.com/YunoHost-Apps/yunohost.multimedia/archive/${ynh_media_release}.tar.gz 2>&1
 
         # Check the control sum
         echo "${checksum} ${ynh_media_release}.tar.gz" | md5sum -c --status \


### PR DESCRIPTION
## Problem

- Moaaar linter warnings #ohno 

```
! Argument --installed ain't needed anymore when using 'yunohost app list'. It directly returns the list of installed apps.. Also beware that option -f is obsolete as well .. Use grep -q 'id: $appname' to check a specific app is installed 
! Please redirect wget's stderr to stdout with 2>&1 to avoid unecessary warnings when the script runs (yes, wget is annoying and displays a warning even when things are going okay >_> ...)
```
## Solution

- Redirect wget stupid warning to stdout
- Remove unecessary `-i` and `-f` when running `yunohost app list`
   - not sure why the command was run in a subshell (parenthesis) ... I validate that running `false && echo 'foo'` doesn't make a script crash even when using `set -eu`

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [X] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/nextcloud_ynh%20PR-NUM-/)  
