### PR TITLE
disable mail app to fix the upgrade from 19 to 20

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -245,7 +245,8 @@ then
     exec_occ -V
 
     # Upgrade may fail if this app is enabled
-    exec_occ app:list | grep -q -w mail
+    # Take all apps enabled, and check if mail is one of them
+    exec_occ app:list | awk '/Enabled/{f=1;next} /Disabled/{f=0} f' | grep -q -w mail
     mail_app_is_active=$?
     
     # Temporary disable the mail app

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -244,6 +244,15 @@ then
     # Print the current version number of Nextcloud
     exec_occ -V
 
+    # Upgrade may fail if this app is enabled
+    exec_occ app:list | grep -q -w mail
+    mail_app_is_active=$?
+    
+    # Temporary disable the mail app
+    if [ $mail_app_is_active -eq 0 ]; then
+        exec_occ app:disable mail
+    fi
+
     # While the current version is not the last version, do an upgrade
     while [ "$last_version" != "$current_version" ]
     do
@@ -345,6 +354,11 @@ then
 
     ynh_replace_string --match_string="__DOMAIN__" --replace_string="$domain" --target_file="$nc_conf"
     ynh_replace_string --match_string="__DATADIR__" --replace_string="$datadir" --target_file="$nc_conf"
+
+    # Reneable the mail app
+    if [ $mail_app_is_active -eq 0 ]; then
+        exec_occ app:enable mail
+    fi
 
     # Ensure that UpdateNotification app is disabled
     exec_occ app:disable updatenotification


### PR DESCRIPTION
## Problem

https://github.com/YunoHost-Apps/nextcloud_ynh/pull/346#issuecomment-751996938
> Upgrade unfortunately still fails if the mail app is installed and enabled...

## Solution
- *Disable mail app during the upgrade*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR360%20(Kay0u)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/nextcloud_ynh%20PR360%20(Kay0u)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
