### PR TITLE
Fixes Nextcloud 21

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -14,7 +14,7 @@ location ^~ /.well-known {
   location = /.well-known/caldav      { return 301 __PATH__/remote.php/dav/; }
  
   # Anything else is dynamically handled by Nextcloud
-  location ^~ /.well-known          { return 301 /nextcloud/index.php$uri; }
+  location ^~ /.well-known          { return 301 __PATH__/index.php$uri; }
 
   try_files $uri $uri/ =404;
 }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -12,6 +12,9 @@ location ^~ /.well-known {
 
   location = /.well-known/carddav     { return 301 __PATH__/remote.php/dav/; }
   location = /.well-known/caldav      { return 301 __PATH__/remote.php/dav/; }
+ 
+  # Anything else is dynamically handled by Nextcloud
+  location ^~ /.well-known          { return 301 /nextcloud/index.php$uri; }
 
   try_files $uri $uri/ =404;
 }


### PR DESCRIPTION
## Problem
https://github.com/YunoHost-Apps/nextcloud_ynh/pull/377#issuecomment-781999502
`/.well-known/webfinger` and `/.well-known/nodeinfo` issue in Nextcloud 21

`Votre installation n’a pas de préfixe de région par défaut. C’est nécessaire pour valider les numéros de téléphone dans les paramètres du profil sans code pays. Pour autoriser les numéros sans code pays, veuillez ajouter "default_phone_region" avec le code ISO 3166-1 respectif de la région dans votre fichier de configuration.`

## Solution
- update nginx as proposed in the docs (https://docs.nextcloud.com/server/21/admin_manual/installation/nginx.html)

- for default_phone_region issue, we have to configure it in `config/config.php`, but I don’t know which one set as default, because there are different country users who install this package... (https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#user-experience)
`
## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.



---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
