### PR TITLE
Make sure to redact admin password

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -147,11 +147,16 @@ exec_occ() {
 # Set write access for the following commands
 chown -R $app: "$final_path" "$datadir"
 
+# Define password in an intermediate var
+# The fact that it's called _password allows it to be
+# picked up by Yunohost's auto-redact mecanism
+admin_password="$(ynh_string_random --length=6)"
+
 # Install Nextcloud using a temporary admin user
 exec_occ maintenance:install \
     --database "mysql" --database-name $db_name \
     --database-user $db_name --database-pass "$db_pwd" \
-    --admin-user "admin" --admin-pass "$(ynh_string_random --length=6)" \
+    --admin-user "admin" --admin-pass "$admin_password" \
     --data-dir "$datadir" \
     || ynh_die --message="Unable to install Nextcloud"
 


### PR DESCRIPTION
## Problem

- Password appearing in clear in logs

## Solution

- The password was not redacted by Yunohost auto-redact mecanism because it looks for patterns like `[something]password=[password]` (like, you put the password in a variable to be used later)

## PR Status

Yolocommited

## Package_check results
---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
