### PR TITLE
Disable HTTP encoding between nextcloud and nginx

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -107,6 +107,7 @@ location ^~ __PATH__/ {
     fastcgi_param HTTPS on;
     fastcgi_param modHeadersAvailable true;         # Avoid sending the security headers twice
     fastcgi_param front_controller_active true;     # Enable pretty urls
+    fastcgi_param HTTP_ACCEPT_ENCODING "";          # Disable encoding of nextcloud response to inject ynh scripts
     fastcgi_pass unix:/var/run/php/php__PHPVERSION__-fpm-__NAME__.sock;
     fastcgi_intercept_errors on;
     fastcgi_request_buffering off;


### PR DESCRIPTION
## Problem
- Yunohost tile not appears #367 

## Solution
- Disable http encoding between nextcloud and nginx to be able to inject script in html.

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 

## Package_check results
---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
