### PR TITLE
typo: `$domain` not defined in `scripts/change_url`

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -117,9 +117,9 @@ fi
 if [ $change_domain -eq 1 ]
 then
 	# Check if .well-known is available for this domain
-	if is_url_handled --domain="$domain" --path="/.well-known/caldav" || is_url_handled --domain="$domain" --path="/.well-known/carddav"
+	if is_url_handled --domain="$new_domain" --path="/.well-known/caldav" || is_url_handled --domain="$new_domain" --path="/.well-known/carddav"
 	then
-		ynh_print_warn --message="Another app already uses the domain $domain to serve a caldav/carddav feature. You may encounter issues when dealing with your calendar or address book."
+		ynh_print_warn --message="Another app already uses the domain $new_domain to serve a caldav/carddav feature. You may encounter issues when dealing with your calendar or address book."
 
 		# Remove lines about .well-known/carddav and caldav with sed.
 		sed --in-place --regexp-extended '/location = \/\.well\-known\/(caldav|carddav)/d' "/etc/nginx/conf.d/$new_domain.d/$app.conf"


### PR DESCRIPTION
## Problem

- This line uses `$domain` but it's undefined: https://github.com/YunoHost-Apps/nextcloud_ynh/blob/testing/scripts/change_url#L120
- this creates :
```
root@yunohost:~# yunohost app change-url nextcloud -d nextcloud.example.com -p nextcloud
Info: [++..................] > Loading installation settings...
Info: [##+++...............] > Backing up the app before changing its URL (may take a while)...
Info: [#####+++++..........] > Updating NGINX web server configuration...
Info: [##########+++++.....] > Applying Nextcloud specific modifications...
Warning: ./change_url: line 120: domain: unbound variable
Warning: [Error] Upgrade failed.
```

## Solution

- Changed by `$new_domain` (I guess it's not `$old_domain`)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
