### PR TITLE
extra_php_dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Online storage, file sharing platform and various other applications
 
-**Shipped version:** 22.2.0~ynh1
+**Shipped version:** 22.2.1~ynh1
 
 **Demo:** https://demo.nextcloud.com/
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Online storage, file sharing platform and various other applications
 
-**Shipped version:** 22.2.1~ynh1
+**Shipped version:** 22.2.2~ynh1
 
 **Demo:** https://demo.nextcloud.com/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -13,7 +13,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Stockage en ligne, plateforme de partage de fichiers et diverses autres applications
 
-**Version incluse :** 22.2.0~ynh1
+**Version incluse :** 22.2.1~ynh1
 
 **Démo :** https://demo.nextcloud.com/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -13,7 +13,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Stockage en ligne, plateforme de partage de fichiers et diverses autres applications
 
-**Version incluse :** 22.2.1~ynh1
+**Version incluse :** 22.2.2~ynh1
 
 **Démo :** https://demo.nextcloud.com/
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -21,11 +21,6 @@ location ^~ __PATH__/ {
   # Path to source
   alias __FINALPATH__/;
 
-  # Force usage of https
-  if ($scheme = http) {
-    rewrite ^ https://$server_name$request_uri? permanent;
-  }
-
   # Add headers to serve security related headers
   more_set_headers "Strict-Transport-Security: max-age=15768000; includeSubDomains; preload;";
   more_set_headers "Referrer-Policy: no-referrer";

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
         "email": "pierre@kayou.io"
     },
     "requirements": {
-        "yunohost": ">= 4.2.8.3"
+        "yunohost": ">= 4.3.0"
     },
     "multi_instance": true,
     "services": [

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Online storage, file sharing platform and various other applications",
         "fr": "Stockage en ligne, plateforme de partage de fichiers et diverses autres applications"
     },
-    "version": "22.2.1~ynh1",
+    "version": "22.2.2~ynh1",
     "url": "https://nextcloud.com",
     "upstream": {
         "license": "AGPL-3.0",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Online storage, file sharing platform and various other applications",
         "fr": "Stockage en ligne, plateforme de partage de fichiers et diverses autres applications"
     },
-    "version": "22.2.0~ynh1",
+    "version": "22.2.1~ynh1",
     "url": "https://nextcloud.com",
     "upstream": {
         "license": "AGPL-3.0",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,10 +3,8 @@
 # COMMON VARIABLES
 #=================================================
 
-pkg_dependencies="imagemagick libmagickcore-6.q16-6-extra acl tar smbclient at"
-
 YNH_PHP_VERSION="7.3"
-extra_php_dependencies="php${YNH_PHP_VERSION}-bz2 php${YNH_PHP_VERSION}-imap php${YNH_PHP_VERSION}-gmp php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-json php${YNH_PHP_VERSION}-intl php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-apcu php${YNH_PHP_VERSION}-redis php${YNH_PHP_VERSION}-ldap php${YNH_PHP_VERSION}-imagick php${YNH_PHP_VERSION}-zip php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-mysql php${YNH_PHP_VERSION}-igbinary php${YNH_PHP_VERSION}-bcmath"
+pkg_dependencies="imagemagick libmagickcore-6.q16-6-extra acl tar smbclient at php${YNH_PHP_VERSION}-bz2 php${YNH_PHP_VERSION}-imap php${YNH_PHP_VERSION}-gmp php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-json php${YNH_PHP_VERSION}-intl php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-apcu php${YNH_PHP_VERSION}-redis php${YNH_PHP_VERSION}-ldap php${YNH_PHP_VERSION}-imagick php${YNH_PHP_VERSION}-zip php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-mysql php${YNH_PHP_VERSION}-igbinary php${YNH_PHP_VERSION}-bcmath"
 
 #=================================================
 # EXPERIMENTAL HELPERS

--- a/scripts/install
+++ b/scripts/install
@@ -104,7 +104,7 @@ ynh_system_user_create --username=$app
 ynh_script_progression --message="Configuring PHP-FPM..." --weight=50
 
 # Create a dedicated php-fpm config
-ynh_add_fpm_config --usage=medium --footprint=high --phpversion=$YNH_PHP_VERSION --package="$extra_php_dependencies"
+ynh_add_fpm_config --usage=medium --footprint=high --phpversion=$YNH_PHP_VERSION
 # Used by ynh_add_nginx_config
 phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -100,7 +100,7 @@ ynh_script_progression --message="Reconfiguring PHP-FPM..." --weight=50
 ynh_restore_file --origin_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 
 # Recreate a dedicated php-fpm config
-ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint --phpversion=$phpversion --package="$extra_php_dependencies"
+ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint --phpversion=$phpversion
 
 #=================================================
 # RESTORE THE CRON FILE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -151,7 +151,7 @@ then
 fi
 
 # Recreate a dedicated PHP-FPM config
-ynh_add_fpm_config --phpversion=$phpversion --usage=$fpm_usage --footprint=$fpm_footprint --package="$extra_php_dependencies"
+ynh_add_fpm_config --phpversion=$phpversion --usage=$fpm_usage --footprint=$fpm_footprint
 
 # Delete existing ini configuration file (backward compatibility)
 if [ -f /etc/php/$phpversion/fpm/conf.d/20-$app.ini ]; then

--- a/scripts/upgrade.d/upgrade.last.sh
+++ b/scripts/upgrade.d/upgrade.last.sh
@@ -4,4 +4,4 @@
 next_version="22.2.1"
 
 # Nextcloud tarball checksum sha256
-nextcloud_source_sha256="6dc8d7f66e74110e4669eeb97d092c86dbb61079cc6d231bca90602c7b8a50ee"
+nextcloud_source_sha256="d01b50b7bb225181a21151a451899dd208df71cab890884255a39347d7ebbf2b"

--- a/scripts/upgrade.d/upgrade.last.sh
+++ b/scripts/upgrade.d/upgrade.last.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Last available Nextcloud version
-next_version="22.2.1"
+next_version="22.2.2"
 
 # Nextcloud tarball checksum sha256
-nextcloud_source_sha256="d01b50b7bb225181a21151a451899dd208df71cab890884255a39347d7ebbf2b"
+nextcloud_source_sha256="943be7dbd375f4b866dcfd9821533ff39bebfd4d3ba91f8cf13905fc3fc64df0"

--- a/scripts/upgrade.d/upgrade.last.sh
+++ b/scripts/upgrade.d/upgrade.last.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Last available Nextcloud version
-next_version="22.2.0"
+next_version="22.2.1"
 
 # Nextcloud tarball checksum sha256
-nextcloud_source_sha256="273dba3ce43501b897e8b78996b50329e31da2b5402866ac20b318cdaddf3e1f"
+nextcloud_source_sha256="6dc8d7f66e74110e4669eeb97d092c86dbb61079cc6d231bca90602c7b8a50ee"


### PR DESCRIPTION
- Remove `extra_php_dependencies` in favor of `pkg_dependencies`
- Needs version 4.3