### PR TITLE
Remove default expires policy in nginx (breaking API calls by caching…

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -8,7 +8,7 @@ location ^~ /.well-known {
 
   location = /.well-known/carddav     { return 301 __PATH__/remote.php/dav/; }
   location = /.well-known/caldav      { return 301 __PATH__/remote.php/dav/; }
- 
+
   location = /.well-known/webfinger     { return 301 __PATH__/index.php$uri; }
   location = /.well-known/nodeinfo      { return 301 __PATH__/index.php$uri; }
 
@@ -61,9 +61,6 @@ location ^~ __PATH__/ {
   # `try_files $uri $uri/ /nextcloud/index.php$request_uri`
   # always provides the desired behaviour.
   index index.php index.html __PATH__/index.php$request_uri;
-
-  # Default Cache-Control policy
-  expires 1m;
 
   # Rule borrowed from `.htaccess` to handle Microsoft DAV clients
   location = __PATH__/ {


### PR DESCRIPTION
… them) (fix #484)

## Problem

- Fix #484

## Solution

- Remove the default `expires` directive, following documentation: https://github.com/nextcloud/documentation/issues/5472

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
