### PR TITLE
opcache.interned_strings_buffer > 8

### DIFF
--- a/conf/extra_php-fpm.conf
+++ b/conf/extra_php-fpm.conf
@@ -10,7 +10,7 @@ php_value[default_charset] = UTF-8
 ; The following parameters are nevertheless recommended for Nextcloud
 ; see here: https://docs.nextcloud.com/server/15/admin_manual/installation/server_tuning.html#enable-php-opcache
 php_value[opcache.enable_cli]=1
-php_value[opcache.interned_strings_buffer]=8
+php_value[opcache.interned_strings_buffer]=10
 php_value[opcache.max_accelerated_files]=10000
 php_value[opcache.memory_consumption]=128
 php_value[opcache.save_comments]=1


### PR DESCRIPTION
Because I got a warning about it in the Nextcloud settings. The recommendation should be higher than 8 so randomly i've put 10, restart php-fpm and no more warning.

## Problem

- *Description of why you made this PR*

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
