### PR TITLE
32 bit support :  warn but don't block upgrade/install (v25)

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -43,7 +43,7 @@ ynh_webpath_register --app=$app --domain=$domain --path_url=$path_url
 # Check machine architecture (Seens 25.0 Nextcloud doesn't support 32bit machines)
 if [ $YNH_ARCH == "i386" ] || [ $YNH_ARCH == "armhf" ]
 then
-    ynh_die --message="Sorry, Nextcloud has deprecated 32-bit support"
+    ynh_print_warn --message="Nextcloud has deprecated 32-bit support. Version 25 is the last one to support 32-bit archytectures."
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -37,7 +37,7 @@ upgrade_type=$(ynh_check_app_version_changed)
 # Check machine architecture (Seens 25.0 Nextcloud doesn't support 32bit machines)
 if [ $YNH_ARCH == "i386" ] || [ $YNH_ARCH == "armhf" ]
 then
-    ynh_die --message="Sorry, Nextcloud has deprecated 32-bit support"
+    ynh_print_warn --message="Nextcloud has deprecated 32-bit support. Version 25 is the last one to support 32-bit archytectures."
 fi
 
 #=================================================


### PR DESCRIPTION
## Problem

- https://github.com/YunoHost-Apps/nextcloud_ynh/pull/517#issuecomment-1345346306

## Solution

- Change it to a simple warning

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
