### PR TITLE
Fix security warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ this package:
  * Serve `/.well-known` paths for CalDAV and CardDAV on the domain only if it's not already served - i.e. by Baïkal
 
 
-**Shipped version:** 25.0.5~ynh1
+**Shipped version:** 25.0.5~ynh2
 
 **Demo:** https://demo.nextcloud.com/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -29,7 +29,7 @@ En plus des fonctionnalités principales de Nextcloud, les fonctionnalités suiv
  * Utilise l'adresse `/.well-known` pour la synchronisation CalDAV et CardDAV du domaine si aucun autre service ne l'utilise déjà - par exemple, Baïkal
 
 
-**Version incluse :** 25.0.5~ynh1
+**Version incluse :** 25.0.5~ynh2
 
 **Démo :** https://demo.nextcloud.com/
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -28,7 +28,7 @@ location ^~ __PATH__/ {
   more_set_headers "X-Download-Options: noopen";
   more_set_headers "X-Frame-Options: SAMEORIGIN";
   more_set_headers "X-Permitted-Cross-Domain-Policies: none";
-  more_set_headers "X-Robots-Tag: none";
+  more_set_headers "X-Robots-Tag: noindex, nofollow";
   more_set_headers "X-XSS-Protection: 1; mode=block";
 
   # Set max upload size

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Online storage, file sharing platform and various other applications",
         "fr": "Stockage en ligne, plateforme de partage de fichiers et diverses autres applications"
     },
-    "version": "25.0.5~ynh1",
+    "version": "25.0.5~ynh2",
     "url": "https://nextcloud.com",
     "upstream": {
         "license": "AGPL-3.0",


### PR DESCRIPTION
cf. https://forum.yunohost.org/t/nextcloud-security-warning-x-robots-tag-http-header-is-not-set-as-noindex-nofollow/24235/1