### PR TITLE
Fix /ocm-provider/” and “/ocs-provider/” on NGINX server warnings

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -114,7 +114,7 @@ location ^~ __PATH__/ {
 
   location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite|map)$ {
     try_files $uri / __PATH__/index.php$request_uri;
-    expires 6M;        # Cache-Control policy borrowed from `.htaccess`
+    expires 6M;         # Cache-Control policy borrowed from `.htaccess`
     access_log off;     # Optional: Don't log access to assets
 
     location ~ \.wasm$ {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -110,7 +110,6 @@ location ^~ __PATH__/ {
   location ~ ^/(?:updater|oc[ms]-provider)(?:$|/) {
        try_files $uri/ =404;
        index index.php;
-    
   }
 
   location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite|map)$ {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -109,8 +109,7 @@ location ^~ __PATH__/ {
 
   location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite|map)$ {
     try_files $uri / __PATH__/index.php$request_uri;
-    more_set_headers "Cache-Control: public, max-age=15778463, $asset_immutable";
-    #expires 6M;        # Cache-Control policy borrowed from `.htaccess`
+    expires 6M;        # Cache-Control policy borrowed from `.htaccess`
     access_log off;     # Optional: Don't log access to assets
 
     location ~ \.wasm$ {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -115,6 +115,7 @@ location ^~ __PATH__/ {
 
     location ~ \.wasm$ {
             default_type application/wasm;
+    }
   }
 
   location ~ \.woff2?$ {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -107,6 +107,12 @@ location ^~ __PATH__/ {
     fastcgi_request_buffering off;
   }
 
+  location ~ ^/(?:updater|oc[ms]-provider)(?:$|/) {
+       try_files $uri/ =404;
+       index index.php;
+    
+  }
+
   location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite|map)$ {
     try_files $uri / __PATH__/index.php$request_uri;
     expires 6M;        # Cache-Control policy borrowed from `.htaccess`

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -77,7 +77,7 @@ location ^~ __PATH__/ {
 
   # Rules borrowed from `.htaccess` to hide certain paths from clients
   location ~ ^__PATH__/(?:build|tests|config|lib|3rdparty|templates|data)(?:$|/)    { return 404; }
-  location ~ ^__PATH__/(?:\.|autotest|occ|issue|indie|db_|console)                { return 404; }
+  location ~ ^__PATH__/(?:\.|autotest|occ|issue|indie|db_|console)                  { return 404; }
 
   # Ensure this block, which passes PHP files to the PHP process, is above the blocks
   # which handle static assets (as seen below). If this block is not declared first,
@@ -88,14 +88,17 @@ location ^~ __PATH__/ {
     # https://github.com/nextcloud/documentation/pull/2197#issuecomment-721432337
     # This line fix the ldap admin page
     rewrite ^__PATH__/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) __PATH__/index.php$request_uri;
+    
     fastcgi_split_path_info ^(.+?\.php)(/.*)$;
     set $path_info $fastcgi_path_info;
+    
     try_files $fastcgi_script_name =404;
+    
     include fastcgi_params;
-
     fastcgi_param SCRIPT_FILENAME $request_filename;
     fastcgi_param PATH_INFO $path_info;
     fastcgi_param HTTPS on;
+
     fastcgi_param modHeadersAvailable true;         # Avoid sending the security headers twice
     fastcgi_param front_controller_active true;     # Enable pretty urls
     fastcgi_param HTTP_ACCEPT_ENCODING "";          # Disable encoding of nextcloud response to inject ynh scripts
@@ -104,10 +107,14 @@ location ^~ __PATH__/ {
     fastcgi_request_buffering off;
   }
 
-  location ~ \.(?:css|js|svg|gif)$ {
+  location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite|map)$ {
     try_files $uri / __PATH__/index.php$request_uri;
-    expires 6M;         # Cache-Control policy borrowed from `.htaccess`
+    more_set_headers "Cache-Control: public, max-age=15778463, $asset_immutable";
+    #expires 6M;        # Cache-Control policy borrowed from `.htaccess`
     access_log off;     # Optional: Don't log access to assets
+
+    location ~ \.wasm$ {
+            default_type application/wasm;
   }
 
   location ~ \.woff2?$ {


### PR DESCRIPTION
fix for [“Not properly set up to resolve “/ocm-provider/” and “/ocs-provider/” on NGINX server](https://help.nextcloud.com/t/with-nextcloud-update-not-properly-set-up-to-resolve-ocm-provider-and-ocs-provider-on-nginx-server/158528) warnings