### PR TITLE
Add -r to xargs to not miserably fail when find doesn't list any file

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -336,10 +336,10 @@ ynh_multimedia_addaccess $app
 # Fix app ownerships & permissions
 chown -R $app:www-data "$final_path"
 chown -R $app: "$datadir"
-find $final_path/ -type f -print0 | xargs -0 chmod 0644
-find $final_path/ -type d -print0 | xargs -0 chmod 0755
-find $datadir/ -type f -print0 | xargs -0 chmod 0640
-find $datadir/ -type d -print0 | xargs -0 chmod 0750
+find $final_path/ -type f -print0 | xargs -r0 chmod 0644
+find $final_path/ -type d -print0 | xargs -r0 chmod 0755
+find $datadir/ -type f -print0 | xargs -r0 chmod 0640
+find $datadir/ -type d -print0 | xargs -r0 chmod 0750
 chmod 640 "$final_path/config/config.php"
 chmod 755 /home/yunohost.app
 chmod 750 $final_path

--- a/scripts/restore
+++ b/scripts/restore
@@ -139,10 +139,10 @@ mkdir -p "$datadir"
 # Fix app ownerships & permissions
 chown -R $app:www-data "$final_path"
 chown -R $app: "$datadir"
-find $final_path/ -type f -print0 | xargs -0 chmod 0644
-find $final_path/ -type d -print0 | xargs -0 chmod 0755
-find $datadir/ -type f -print0 | xargs -0 chmod 0640
-find $datadir/ -type d -print0 | xargs -0 chmod 0750
+find $final_path/ -type f -print0 | xargs -r0 chmod 0644
+find $final_path/ -type d -print0 | xargs -r0 chmod 0755
+find $datadir/ -type f -print0 | xargs -r0 chmod 0640
+find $datadir/ -type d -print0 | xargs -r0 chmod 0750
 chmod 640 "$final_path/config/config.php"
 chmod 755 /home/yunohost.app
 chmod 750 $final_path

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -452,10 +452,10 @@ exec_occ background:cron
 # Fix app ownerships & permissions
 chown -R $app:www-data "$final_path"
 chown -R $app: "$datadir"
-find $final_path/ -type f -print0 | xargs -0 chmod 0644
-find $final_path/ -type d -print0 | xargs -0 chmod 0755
-find $datadir/ -type f -print0 | xargs -0 chmod 0640
-find $datadir/ -type d -print0 | xargs -0 chmod 0750
+find $final_path/ -type f -print0 | xargs -r0 chmod 0644
+find $final_path/ -type d -print0 | xargs -r0 chmod 0755
+find $datadir/ -type f -print0 | xargs -r0 chmod 0640
+find $datadir/ -type d -print0 | xargs -r0 chmod 0750
 chmod 640 "$final_path/config/config.php"
 chmod 755 /home/yunohost.app
 chmod 750 $final_path


### PR DESCRIPTION
## Problem

cf for example https://forum.yunohost.org/t/cant-restore-nextcloud/25083/2

The datadir did not contain any file, hence `find $datadir -type f | xargs -0 chmod 0640` failed because no args was provided to chmod ...

## Solution

There is a `-r` option for `xargs` such that it doesn't run the command at all if there's no input. cf https://unix.stackexchange.com/questions/83709/xargs-r0-vs-xargs-0

For example:

```
mkdir foobar
find foobar -type f | xargs -0 chmod 0640    # will fail (no arg for chmod)
find foobar -type f | xargs -r0 chmod 0640   # will succeed (chmod aint run at all)
```