### PR TITLE
[enh] Cache control on mjs files

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -118,7 +118,7 @@ location ^~ __PATH__/ {
        index index.php;
   }
 
-  location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite|map)$ {
+  location ~ \.(?:css|js|mjs|svg|gif|png|jpg|ico|wasm|tflite|map)$ {
     try_files $uri / __PATH__/index.php$request_uri;
     expires 6M;         # Cache-Control policy borrowed from `.htaccess`
     access_log off;     # Optional: Don't log access to assets


### PR DESCRIPTION
## Problem

No cache on mjs files

## Solution

Add simply mjs files to the location.
Note that the official doc use a tricks to manage in a better way the cache (we just have Expire 6M...
https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html#nextcloud-in-a-subdir-of-the-nginx-webroot

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
