### PR TITLE
27.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ this package:
  * Serve `/.well-known` paths for CalDAV and CardDAV on the domain only if it's not already served - i.e. by Baïkal
 
 
-**Shipped version:** 27.1.2~ynh3
+**Shipped version:** 27.1.4~ynh1
 
 **Demo:** https://demo.nextcloud.com/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -29,7 +29,7 @@ En plus des fonctionnalités principales de Nextcloud, les fonctionnalités suiv
  * Utilise l'adresse `/.well-known` pour la synchronisation CalDAV et CardDAV du domaine si aucun autre service ne l'utilise déjà - par exemple, Baïkal
 
 
-**Version incluse :** 27.1.2~ynh3
+**Version incluse :** 27.1.4~ynh1
 
 **Démo :** https://demo.nextcloud.com/
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Online storage, file sharing platform and various other applications",
         "fr": "Stockage en ligne, plateforme de partage de fichiers et diverses autres applications"
     },
-    "version": "27.1.2~ynh3",
+    "version": "27.1.4~ynh1",
     "url": "https://nextcloud.com",
     "upstream": {
         "license": "AGPL-3.0",

--- a/scripts/upgrade.d/upgrade.last.sh
+++ b/scripts/upgrade.d/upgrade.last.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Last available Nextcloud version
-next_version="27.1.2"
+next_version="27.1.4"
 
 # Nextcloud tarball checksum sha256
-nextcloud_source_sha256="0742b247aaee0b7044db0062f0a914aa77338c7a7d8fe7da0917147d76689721"
+nextcloud_source_sha256="bec65f2166b82c9303baf476c1e424f71aa196dad010ffe4c0c39d03990d594c"


### PR DESCRIPTION
## Problem

 * security (due to CVE publication on external storage) https://www.cert.ssi.gouv.fr/avis/CERTFR-2023-AVI-0968/
 * stability reasons https://forum.chatons.org/t/processus-php-fpm-bloques-par-des-requetes-en-base-de-donnees/5464.

## Solution
I suggest just upgrade the hash on master and test in a better way the new v2 format Testing.


## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

