### PR TITLE
[fix] overwrite.cli.url should contains path

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -198,7 +198,7 @@ exec_occ config:system:get logout_url >/dev/null 2>&1 \
 # CHANGE HOSTNAME FOR ACTIVITY NOTIFICATIONS
 #=================================================
 
-exec_occ config:system:set overwrite.cli.url --value="https://${domain}"
+exec_occ config:system:set overwrite.cli.url --value="https://${domain}${path}"
 
 #=================================================
 # REMOVE THE TEMPORARY ADMIN AND SET THE TRUE ONE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -312,7 +312,7 @@ EOF
     # CHANGE HOSTNAME FOR ACTIVITY NOTIFICATIONS
     #=================================================
 
-    exec_occ config:system:set overwrite.cli.url --value="https://${domain}"
+    exec_occ config:system:set overwrite.cli.url --value="https://${domain}${path}"
 
     #=================================================
     # MOUNT HOME FOLDERS AS EXTERNAL STORAGE


### PR DESCRIPTION
## Problem

Doc says the subpath should be in the `overwrite.cli.url` https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#overwrite-cli-url

## Solution
Add the $path

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
