### PR TITLE
Upgrade script: check that installed apps are compatible with the future version before actually starting the upgrade

### DIFF
--- a/doc/PRE_UPGRADE.md
+++ b/doc/PRE_UPGRADE.md
@@ -1,1 +1,3 @@
 If you are upgrading to a new major version of Nextcloud, please make sure that your Nextcloud apps are up to date from Nextcloud's administration panel beforehand.
+
+Additionally, if you installed specific Nextcloud apps, we recommend making sure that they are compatible with the new major version. YunoHost will attempt to check this automatically at the very beginning of the upgrade, but a manual check doesn't hurt either. For Nextcloud 28, this forum thread might be helpful : <https://help.nextcloud.com/t/apps-not-compatible-with-nc-28/176234>.

--- a/doc/PRE_UPGRADE.md
+++ b/doc/PRE_UPGRADE.md
@@ -1,0 +1,1 @@
+If you are upgrading to a new major version of Nextcloud, please make sure that your Nextcloud apps are up to date from Nextcloud's administration panel beforehand.

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -74,15 +74,44 @@ local mount_id=$(exec_occ files_external:create --output=json \
     || exec_occ files_external:option "$mount_id" enable_sharing true
 }
 
+function list_installed_apps_not_compatible_with_future_version()
+{
+    local nextcloud_destination_version="$1"
+    local nextcloud_current_version="$(grep OC_VersionString "$install_dir/version.php" | cut -d\' -f2)"
+    local installed_apps=$(mktemp)
+    local core_apps_in_current_version=$(mktemp)
+    local nextcloud_destination_appcatalog=$(mktemp)
+
+    # List installed apps
+    exec_occ app:list --output json | jq -r ".enabled | keys[]" | sort > $installed_apps
+    # Fetch Nextcloud list of core apps from their github repo for the current version
+    curl -s https://raw.githubusercontent.com/nextcloud/server/v$nextcloud_current_version.0.0/core/shipped.json | jq -r '.shippedApps[]' | sort > $core_apps_in_current_version
+    # Fetch Nextcloud app catalog (doesnt contain core app) for the future version
+    curl -s https://apps.nextcloud.com/api/v1/platform/$nextcloud_destination_appcatalog.0.0/apps.json | jq -r '.[] | .id' | sort > $nextcloud_destination_appcatalog
+
+    # Compute set complement, cf https://catonmat.net/set-operations-in-unix-shell
+    # We want to list the installed apps which are neither core apps nor in the destination catalog
+    comm -23 <(comm -23 $installed_apps $core_apps_in_current_version) $nextcloud_destination_appcatalog
+}
+
+# Load the last available version
+source upgrade.d/upgrade.last.sh
+last_version=$next_version
+
+last_major_version=${last_version%%.*}
+
+if [[ "$last_major_version" != "$current_major_version" ]]
+then
+    installed_apps_not_compatible_with_future_version="$(list_installed_apps_not_compatible_with_future_version $last_major_version)"
+    if [[ -n "$installed_apps_not_compatible_with_future_version" ]]
+    then
+        ynh_die --message="The following apps are not (yet?) compatible with Nextcloud $last_major_version. You should make sure to upgrade the app, or disable it, or wait for it to become compatible before running this upgrade : $installed_apps_not_compatible_with_future_version"
+    fi
+fi
+
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
     ynh_script_progression --message="Upgrading Nextcloud..." --weight=3
-
-    # Load the last available version
-    source upgrade.d/upgrade.last.sh
-    last_version=$next_version
-
-    last_major_version=${last_version%%.*}
 
     # Set write access for the following commands
     chown -R $app: "$install_dir" "$data_dir"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -85,7 +85,7 @@ function list_installed_apps_not_compatible_with_future_version()
     # List installed apps
     exec_occ app:list --output json | jq -r ".enabled | keys[]" | sort > $installed_apps
     # Fetch Nextcloud list of core apps from their github repo for the current version
-    curl -s https://raw.githubusercontent.com/nextcloud/server/v$nextcloud_current_version.0.0/core/shipped.json | jq -r '.shippedApps[]' | sort > $core_apps_in_current_version
+    curl -s https://raw.githubusercontent.com/nextcloud/server/v$nextcloud_current_version/core/shipped.json | jq -r '.shippedApps[]' | sort > $core_apps_in_current_version
     # Fetch Nextcloud app catalog (doesnt contain core app) for the future version
     curl -s https://apps.nextcloud.com/api/v1/platform/$nextcloud_destination_appcatalog.0.0/apps.json | jq -r '.[] | .id' | sort > $nextcloud_destination_appcatalog
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -87,7 +87,7 @@ function list_installed_apps_not_compatible_with_future_version()
     # Fetch Nextcloud list of core apps from their github repo for the current version
     curl -s https://raw.githubusercontent.com/nextcloud/server/v$nextcloud_current_version/core/shipped.json | jq -r '.shippedApps[]' | sort > $core_apps_in_current_version
     # Fetch Nextcloud app catalog (doesnt contain core app) for the future version
-    curl -s https://apps.nextcloud.com/api/v1/platform/$nextcloud_destination_appcatalog.0.0/apps.json | jq -r '.[] | .id' | sort > $nextcloud_destination_appcatalog
+    curl -s https://apps.nextcloud.com/api/v1/platform/$nextcloud_destination_version.0.0/apps.json | jq -r '.[] | .id' | sort > $nextcloud_destination_appcatalog
 
     # Compute set complement, cf https://catonmat.net/set-operations-in-unix-shell
     # We want to list the installed apps which are neither core apps nor in the destination catalog

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -91,7 +91,7 @@ function list_installed_apps_not_compatible_with_future_version()
 
     # Run a first "dummy" command just to make sure we have the appropriate php dependencies installed,
     # otherwise this creates funky stuff when tweaking the apt deps because the next command is piped into jq ...
-    exec_occ -V
+    exec_occ -V >/dev/null
     # List installed apps
     exec_occ app:list --output json | jq -r ".enabled | keys[]" | sort > $installed_apps
     # Fetch Nextcloud list of core apps from their github repo for the current version

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -89,6 +89,9 @@ function list_installed_apps_not_compatible_with_future_version()
     local core_apps_in_current_version=$(mktemp)
     local nextcloud_destination_appcatalog=$(mktemp)
 
+    # Run a first "dummy" command just to make sure we have the appropriate php dependencies installed,
+    # otherwise this creates funky stuff when tweaking the apt deps because the next command is piped into jq ...
+    exec_occ -V
     # List installed apps
     exec_occ app:list --output json | jq -r ".enabled | keys[]" | sort > $installed_apps
     # Fetch Nextcloud list of core apps from their github repo for the current version


### PR DESCRIPTION
## Problem

- cf the classic issue of "Upgrade miserably fails" ... *share log* ... "Yes, app foobar is not compatible ..."
- fix https://github.com/YunoHost-Apps/nextcloud_ynh/issues/590 i guess ?

## Solution

- Implement a check that the installed apps are compatible ... this is not trivial : 
   - gotta list the installed apps (this part is mostly straightforward)
   - substract the "core" apps which are always compatible ... listed in https://github.com/nextcloud/server/blob/master/core/shipped.json
   - substract the apps that will indeed be available in the future version ... listed in https://apps.nextcloud.com/api/v1/platform/28.0.0/apps.json (for 28.x)

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
