### PR TITLE
Filter boring occ warnings during upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -34,6 +34,14 @@ fi
 current_version=$(grep OC_VersionString "$install_dir/version.php" | cut -d\' -f2)
 current_major_version=${current_version%%.*}
 
+filter_boring_occ_warnings() {
+    # Filter stupid and boring messages such as the progress bar looking like:
+    # 3/3 [============================] 100% Starting ...
+    # and being pretty much useless, as well as the annoying warning about "only a limited number of commands" etc...
+
+    sed -E 's@\s*([0-9]+\/[0-9]+\s+\[(-|>|=)+\]\s+[0-9]+%|\s*Starting ...|Nextcloud or one of the apps require upgrade - only a limited number of commands are available|You may use your browser or the occ upgrade command to do the upgrade)@@g'
+}
+
 # Define a function to execute commands with `occ`
 exec_occ() {
     # Backward compatibility to upgrade from older versions
@@ -59,7 +67,7 @@ exec_occ() {
         ynh_install_app_dependencies "$pkg_dependencies"
     fi 
 (cd "$install_dir" && ynh_exec_as "$app" \
-    php$NEXTCLOUD_PHP_VERSION --define apc.enable_cli=1 occ --no-interaction --no-ansi "$@")
+    php$NEXTCLOUD_PHP_VERSION --define apc.enable_cli=1 occ --no-interaction --no-ansi "$@") 2> >(filter_boring_occ_warnings >&2)
 }
 
 # Define a function to add an external storage


### PR DESCRIPTION
## Problem

- cf all these screenshots / logs with a shitload of `0/0 [->--------------------------]   0% Starting ...` or `Nextcloud or one of the apps require upgrade`

## Solution

- Magic