### PR TITLE
Fix PHP/APT dependency confusion when upgrading through many versions

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -56,6 +56,10 @@ exec_occ() {
     if [[ "$NEXTCLOUD_PHP_VERSION" != "$phpversion" ]]; then
         local pkg_dependencies="$(dpkg-query --show --showformat='${Depends}' ${app}-ynh-deps)"
         pkg_dependencies="${pkg_dependencies//$phpversion/$NEXTCLOUD_PHP_VERSION}"
+        # Packaging v1 ~legacy : ynh_install_app_dependencies is designed to be called several times
+        # but the second time it will *append* the list of dependencies rather than replace the existing dependencies
+        # resulting in a crash when parsing what's the php version the app uses, hence we need to force the full-replacement
+        YNH_INSTALL_APP_DEPENDENCIES_REPLACE=true
         ynh_install_app_dependencies "$pkg_dependencies"
     fi 
 (cd "$install_dir" && ynh_exec_as "$app" \


### PR DESCRIPTION
## Problem

- Fix https://github.com/YunoHost-Apps/nextcloud_ynh/issues/650 , with the code ending up with `phpversion='7.4;8.1'` because `ynh_install_app_dependencies` is called several times, and the second time it *appends* (rather than *replace*) the list of dependencies

## Solution

- Force the helper to replace the dependencies
