### PR TITLE
New source format

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -3,7 +3,7 @@
 You can run Nextcloud commands from the command line using:
 
 ```
-sudo -u __APP__ php__YNH_PHP_VERSION__ --define apc.enable_cli=1 __INSTALL_DIR__/occ ...
+sudo -u __APP__ php__PHPVERSION__ --define apc.enable_cli=1 __INSTALL_DIR__/occ ...
 ```
 
 Alternatively, you may open a 'Nextcloud shell' with `sudo yunohost app shell __APP__`, then run `php occ ...`

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -3,7 +3,7 @@
 Vous pouvez lancer des commandes Nextcloud depuis la ligne de commande avec:
 
 ```
-sudo -u __APP__ php__YNH_PHP_VERSION__ --define apc.enable_cli=1 __INSTALL_DIR__/occ ...
+sudo -u __APP__ php__PHPVERSION__ --define apc.enable_cli=1 __INSTALL_DIR__/occ ...
 ```
 
 Ou bien, vous pouvez ouvrir un "shell Nextcloud" avec `sudo yunohost app shell __APP__`, puis lancer `php occ ...`

--- a/manifest.toml
+++ b/manifest.toml
@@ -28,7 +28,7 @@ ldap = true
 sso = true
 
 disk = "650M"
-ram.build = "500M"
+ram.build = "250M"
 ram.runtime = "512M"
 
 [install]

--- a/manifest.toml
+++ b/manifest.toml
@@ -27,7 +27,7 @@ ldap = true
 
 sso = true
 
-disk = "50M"
+disk = "650M"
 ram.build = "500M"
 ram.runtime = "512M"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -55,6 +55,38 @@ ram.runtime = "512M"
     default = false
 
 [resources]
+
+    [resources.sources]
+
+        [resources.sources.main]
+        url = 'https://download.nextcloud.com/server/releases/nextcloud-28.0.1.tar.bz2'
+        sha256 = '2f80735b443082272fe6a3b5e32137957f1fc448c75342b94b5200b29725f3a4'
+
+        [resources.sources.27]
+        url = 'https://download.nextcloud.com/server/releases/nextcloud-27.0.0.tar.bz2'
+        sha256 = '3d312a09b9345ac058758dd7b4059bf3cf0b1f0f1d747251b6fac3585ba6533f'
+        prefetch = false
+
+        [resources.sources.26]
+        url = 'https://download.nextcloud.com/server/releases/nextcloud-26.0.0.tar.bz2'
+        sha256 = 'f163150363aee9366ecb5cd5259bf6756ed4f073cea78b5fa515cada7a0d0c3d'
+        prefetch = false
+
+        [resources.sources.25]
+        url = 'https://download.nextcloud.com/server/releases/nextcloud-25.0.0.tar.bz2'
+        sha256 = '2c05ac9d7b72b44ef8b3d2ae03ff0fd6121e254b8054556f5163bd8760dd8f49'
+        prefetch = false
+
+        [resources.sources.24]
+        url = 'https://download.nextcloud.com/server/releases/nextcloud-24.0.0.tar.bz2'
+        sha256 = '176cb5620f20465fb4759bdf3caaebeb7acff39d6c8630351af9f8738c173780'
+        prefetch = false
+
+        [resources.sources.23]
+        url = 'https://download.nextcloud.com/server/releases/nextcloud-23.0.0.tar.bz2'
+        sha256 = 'c37592abc3b65c8fd28459281a24f414b87af52fc8c2ea979be3f9be75d01a2c'
+        prefetch = false
+
     [resources.system_user]
     allow_email = true
 

--- a/scripts/install
+++ b/scripts/install
@@ -21,18 +21,6 @@ ynh_mysql_connect_as --user=$db_user --password="$db_pwd" --database=$db_name \
 #=================================================
 ynh_script_progression --message="Setting up source files..." --weight=5
 
-# Load the last available version
-source upgrade.d/upgrade.last.sh
-
-# Create an app.src for the last version of nextcloud
-cat > ../conf/app.src << EOF
-SOURCE_URL=https://download.nextcloud.com/server/releases/nextcloud-$next_version.tar.bz2
-SOURCE_SUM=$nextcloud_source_sha256
-SOURCE_SUM_PRG=sha256sum
-SOURCE_FORMAT=tar.bz2
-SOURCE_IN_SUBDIR=true
-EOF
-
 # Enable YunoHost patches on Nextcloud sources
 cp -a ../sources/patches_last_version/* ../sources/patches
 # Download, check integrity, uncompress and patch the source from app.src

--- a/scripts/install
+++ b/scripts/install
@@ -108,7 +108,7 @@ exec_occ ldap:create-empty-config
 
 # Load the installation config file in Nextcloud
 nc_conf="$install_dir/config_install.json"
-ynh_add_config --template="../conf/config_install.json" --destination="$nc_conf"
+ynh_add_config --template="config_install.json" --destination="$nc_conf"
 
 exec_occ config:import "$nc_conf"
 
@@ -117,7 +117,7 @@ ynh_secure_remove --file="$nc_conf"
 
 # Load the additional config file (used also for upgrade)
 nc_conf="$install_dir/config.json"
-ynh_add_config --template="../conf/config.json" --destination="$nc_conf"
+ynh_add_config --template="config.json" --destination="$nc_conf"
 
 exec_occ config:import "$nc_conf"
 
@@ -201,7 +201,7 @@ ynh_store_file_checksum --file="$install_dir/config/config.php"
 #=================================================
 
 cron_path="/etc/cron.d/$app"
-ynh_add_config --template="../conf/nextcloud.cron" --destination="$cron_path"
+ynh_add_config --template="nextcloud.cron" --destination="$cron_path"
 chown root: "$cron_path"
 chmod 644 "$cron_path"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -184,7 +184,7 @@ EOF
         # Upgrade Nextcloud (SUCCESS = 0, UP_TO_DATE = 3)
         exec_occ maintenance:mode --off
         exec_occ upgrade \
-        || [ $? -eq 3 ] || ynh_die --message="Unable to upgrade Nextcloud"
+        || [ $? -eq 3 ] || ynh_die --message="Unable to upgrade $app"
 
         # Get the new current version number
         current_version=$(grep OC_VersionString "$install_dir/version.php" | cut -d\' -f2)
@@ -202,13 +202,13 @@ EOF
     #=================================================
     # CONFIGURE NEXTCLOUD
     #=================================================
-    ynh_script_progression --message="Reconfiguring Nextcloud..." --weight=9
+    ynh_script_progression --message="Reconfiguring $app..." --weight=9
 
     # Verify the checksum and backup the file if it's different
     ynh_backup_if_checksum_is_different --file="$install_dir/config/config.php"
 
     nc_conf="${install_dir}/config.json"
-    ynh_add_config --template="../conf/config.json" --destination="$nc_conf"
+    ynh_add_config --template="config.json" --destination="$nc_conf"
 
     # Reneable the mail app
     if [ $mail_app_must_be_reactived -eq 1 ]; then
@@ -295,15 +295,15 @@ chmod 750 $install_dir
 #=================================================
 ynh_script_progression --message="Regenerating system configurations for $app..." --weight=2
 
-# -------
+#-------------------------------------------------
 # PHP-FPM
-# -------
+#-------------------------------------------------
 
 ynh_add_fpm_config
 
-# -------
+#-------------------------------------------------
 # NGINX
-# -------
+#-------------------------------------------------
 
 # Delete current NGINX configuration to be able to check if .well-known is already served.
 ynh_backup_if_checksum_is_different --file="/etc/nginx/conf.d/$domain.d/$app.conf"
@@ -325,24 +325,24 @@ fi
 # Create a dedicated NGINX config
 ynh_add_nginx_config
 
-# -------
+#-------------------------------------------------
 # CRON JOB
-# -------
+#-------------------------------------------------
 cron_path="/etc/cron.d/$app"
-ynh_add_config --template="../conf/nextcloud.cron" --destination="$cron_path"
+ynh_add_config --template="nextcloud.cron" --destination="$cron_path"
 chown root: "$cron_path"
 chmod 644 "$cron_path"
 
 exec_occ background:cron
 
-# -------
+#-------------------------------------------------
 # LOGROTATE
-# -------
+#-------------------------------------------------
 ynh_use_logrotate --non-append
 
-# -------
+#-------------------------------------------------
 # FAIL2BAN
-# -------
+#-------------------------------------------------
 
 # Create a dedicated Fail2Ban config
 ynh_add_fail2ban_config --logpath="/home/yunohost.app/$app/data/nextcloud.log" --failregex="^.*Login failed: '.*' \(Remote IP: '<HOST>'.*$" --max_retry=5

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -19,10 +19,11 @@ if [ -z "${phpflags:-}" ]; then
 	ynh_app_setting_set --app=$app --key=phpflags --value=$phpflags
 fi
 
-# Delete existing ini configuration file (backward compatibility)
-if [ -f /etc/php/$YNH_PHP_VERSION/fpm/conf.d/20-$app.ini ]; then
-    ynh_secure_remove --file=/etc/php/$YNH_PHP_VERSION/fpm/conf.d/20-$app.ini
+if ynh_compare_current_package_version --comparison lt --version 22.2
+then
+    ynh_die --message="Upgrading from Nextcloud < 22.2 is not supported anymore. You should first upgrade to 22.2 using: yunohost app upgrade nextcloud -u https://github.com/YunoHost-Apps/nextcloud_ynh/tree/41f5f902e7c7cd3c30a6793020562ba98b9bf3e9"
 fi
+
 
 #=================================================
 # SPECIFIC UPGRADE
@@ -30,9 +31,6 @@ fi
 # MAKE SEQUENTIAL UPGRADES FROM EACH MAJOR
 # VERSION TO THE NEXT ONE
 #=================================================
-
-current_version=$(grep OC_VersionString "$install_dir/version.php" | cut -d\' -f2)
-current_major_version=${current_version%%.*}
 
 # Define a function to execute commands with `occ`
 exec_occ() {
@@ -43,21 +41,18 @@ exec_occ() {
     elif [ $current_major_version -ge 24 ]
     then
         NEXTCLOUD_PHP_VERSION="8.1"
-    elif [ $current_major_version -ge 18 ]
-    then
-        NEXTCLOUD_PHP_VERSION="7.4"
     else
-        NEXTCLOUD_PHP_VERSION="7.1"
+        NEXTCLOUD_PHP_VERSION="7.4"
     fi
 
-    # NB : be super careful when designing this part of the code, because calling ynh_install_app_dependencies 
+    # NB : be super careful when designing this part of the code, because calling ynh_install_app_dependencies
     # will do magic regarding php configuration and $phpversion when the php version of the dependencies changes ...
     phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
     if [[ "$NEXTCLOUD_PHP_VERSION" != "$phpversion" ]]; then
         local pkg_dependencies="$(dpkg-query --show --showformat='${Depends}' ${app}-ynh-deps)"
         pkg_dependencies="${pkg_dependencies//$phpversion/$NEXTCLOUD_PHP_VERSION}"
         ynh_install_app_dependencies "$pkg_dependencies"
-    fi 
+    fi
 (cd "$install_dir" && ynh_exec_as "$app" \
     php$NEXTCLOUD_PHP_VERSION --define apc.enable_cli=1 occ --no-interaction --no-ansi "$@")
 }
@@ -74,15 +69,15 @@ local mount_id=$(exec_occ files_external:create --output=json \
     || exec_occ files_external:option "$mount_id" enable_sharing true
 }
 
+current_version=$(grep OC_VersionString "$install_dir/version.php" | cut -d\' -f2)
+current_major_version=${current_version%%.*}
+
+last_version=$(ynh_read_manifest --key="resources.sources.main.url" | grep -o '[0-9][0-9]\.[0-9]\.[0-9]')
+last_major_version=${last_version%%.*}
+
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
     ynh_script_progression --message="Upgrading Nextcloud..." --weight=3
-
-    # Load the last available version
-    source upgrade.d/upgrade.last.sh
-    last_version=$next_version
-
-    last_major_version=${last_version%%.*}
 
     # Set write access for the following commands
     chown -R $app: "$install_dir" "$data_dir"
@@ -104,54 +99,30 @@ then
     # Take all apps enabled, and check if mail is one of them
     # Then temporary disable the mail app
     mail_app_must_be_reactived=0
-    
+
     if exec_occ app:list | awk '/Enabled/{f=1;next} /Disabled/{f=0} f' | grep -q -w mail; then
         exec_occ app:disable mail
         mail_app_must_be_reactived=1
     fi
-    
+
     # While the current version is not the last version, do an upgrade
     while [ "$last_version" != "$current_version" ]
     do
 
-        # The major version is the first part of the version number
-        current_major_version=${current_version%%.*}
+        ynh_print_info --message="Upgrade to Nextcloud $last_version"
 
-        if [ ! -f upgrade.d/upgrade.$current_major_version.sh ]; then
-            source upgrade.d/upgrade.last.sh
-        else
-            source upgrade.d/upgrade.$current_major_version.sh
-        fi
-
-        # If the current version has the same major version than the next one,
-        # then it's the last upgrade to do
-        # We also cover the case where the last version is the first of the current major version series
-        # (e.g. 20.0.0 is the latest version)
-        if [[ ("$last_major_version" -eq "$current_major_version") || ( ("$last_major_version" -eq "$((current_major_version+1))") && ("$next_version" == "$last_version") ) ]]; then
-            current_major_version=last
-            # Enable YunoHost patches on Nextcloud sources
+        next_major_version="$(( $current_major_version + 1 ))"
+        if [[ "$next_major_version" -ge "$last_major_version" ]]; then
             cp -a ../sources/patches_last_version/* ../sources/patches
+            source_id="main"
+        else
+            source_id="$next_major_version"
         fi
-
-        # Load the value for this version
-        source upgrade.d/upgrade.$current_major_version.sh
-
-        ynh_print_info --message="Upgrade to Nextcloud $next_version"
-
-        # Create an app.src for this version of Nextcloud
-        cat > ../conf/app.src << EOF
-SOURCE_URL=https://download.nextcloud.com/server/releases/nextcloud-$next_version.tar.bz2
-SOURCE_SUM=$nextcloud_source_sha256
-SOURCE_SUM_PRG=sha256sum
-SOURCE_FORMAT=tar.bz2
-SOURCE_IN_SUBDIR=true
-EOF
 
         # Create a temporary directory
         tmpdir="$(ynh_smart_mktemp min_size=300)"
 
-        # Install the next nextcloud version in $tmpdir
-        ynh_setup_source --dest_dir="$tmpdir"
+        ynh_setup_source --dest_dir="$tmpdir" --source_id="$source_id"
 
         # Backup the config file in the temp dir
         cp -a "$install_dir/config/config.php" "$tmpdir/config/config.php"
@@ -198,7 +169,7 @@ EOF
     exec_occ db:add-missing-columns -n
     exec_occ db:add-missing-primary-keys -n
     exec_occ db:convert-filecache-bigint -n
-    
+
     #=================================================
     # CONFIGURE NEXTCLOUD
     #=================================================

--- a/scripts/upgrade.d/upgrade.10.sh
+++ b/scripts/upgrade.d/upgrade.10.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Version cible de la mise à jour de Nextcloud
-next_version="11.0.0"
-
-# Nextcloud tarball checksum
-nextcloud_source_sha256="5bdfcb36c5cf470b9a6679034cabf88bf1e50a9f3e47c08d189cc2280b621429"

--- a/scripts/upgrade.d/upgrade.11.sh
+++ b/scripts/upgrade.d/upgrade.11.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Version cible de la mise à jour de Nextcloud
-next_version="12.0.0"
-
-# Nextcloud tarball checksum
-nextcloud_source_sha256="1b9d9cf05e657cd564a552b418fbf42d669ca51e0fd1f1f118fe44cbf93a243f"

--- a/scripts/upgrade.d/upgrade.12.sh
+++ b/scripts/upgrade.d/upgrade.12.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Version cible de la mise à jour de Nextcloud
-next_version="13.0.0"
-
-# Nextcloud tarball checksum
-nextcloud_source_sha256="38e6064432a2d1a044f219028d3fd46cb7a943a47e11eef346810bd289705aec"

--- a/scripts/upgrade.d/upgrade.13.sh
+++ b/scripts/upgrade.d/upgrade.13.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available nextcloud version
-next_version="14.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="f965c14286e7aabbfe49c947d86af59597af302c35d10e0b5440e7e6c53b8f47"

--- a/scripts/upgrade.d/upgrade.14.sh
+++ b/scripts/upgrade.d/upgrade.14.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available nextcloud version
-next_version="15.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="5bb0c58171353da844019b64080c21078002a59ab956ab72adb958844a98eb78"

--- a/scripts/upgrade.d/upgrade.15.sh
+++ b/scripts/upgrade.d/upgrade.15.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available nextcloud version
-next_version="16.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="4532f7028b1d9bf060f75ac4fbbde52a59ecd9c9155f3178a038d3cf3609402e"

--- a/scripts/upgrade.d/upgrade.16.sh
+++ b/scripts/upgrade.d/upgrade.16.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available nextcloud version
-next_version="17.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="6081421b33ecdb3130b2bfb2293a3f4045aeb0b471ee570e675de3d931a142a6"

--- a/scripts/upgrade.d/upgrade.17.sh
+++ b/scripts/upgrade.d/upgrade.17.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available nextcloud version
-next_version="18.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="194095a5586d84040bc455f77b8aa6c80f9a6a6dd713c9aebdad046713d4267b"

--- a/scripts/upgrade.d/upgrade.18.sh
+++ b/scripts/upgrade.d/upgrade.18.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available nextcloud version
-next_version="19.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="d23d429657c5e3476d7e73af1eafc70e42a81cfe2ed65b20655a005724fe0aae"

--- a/scripts/upgrade.d/upgrade.19.sh
+++ b/scripts/upgrade.d/upgrade.19.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available nextcloud version
-next_version="20.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="a273e0151f68567f729d9a82a7e3f124ff0f0471aa17bae6bfd83c5362d84cd8"

--- a/scripts/upgrade.d/upgrade.20.sh
+++ b/scripts/upgrade.d/upgrade.20.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available nextcloud version
-next_version="21.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="ceadaeef67685a11afc5b23b0a86ba3c7bd0a7b138d5d1ecc05262383655f1f0"

--- a/scripts/upgrade.d/upgrade.21.sh
+++ b/scripts/upgrade.d/upgrade.21.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available nextcloud version
-next_version="22.2.10"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="8de167bfcfcaa661245a00a5ac36628e7961951b9fe2dfaf4f8a5aac6907ccdb"

--- a/scripts/upgrade.d/upgrade.22.sh
+++ b/scripts/upgrade.d/upgrade.22.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available Nextcloud version
-next_version="23.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="c37592abc3b65c8fd28459281a24f414b87af52fc8c2ea979be3f9be75d01a2c"

--- a/scripts/upgrade.d/upgrade.23.sh
+++ b/scripts/upgrade.d/upgrade.23.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available Nextcloud version
-next_version="24.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="176cb5620f20465fb4759bdf3caaebeb7acff39d6c8630351af9f8738c173780"

--- a/scripts/upgrade.d/upgrade.24.sh
+++ b/scripts/upgrade.d/upgrade.24.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available Nextcloud version
-next_version="25.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="2c05ac9d7b72b44ef8b3d2ae03ff0fd6121e254b8054556f5163bd8760dd8f49"

--- a/scripts/upgrade.d/upgrade.25.sh
+++ b/scripts/upgrade.d/upgrade.25.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available Nextcloud version
-next_version="26.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="f163150363aee9366ecb5cd5259bf6756ed4f073cea78b5fa515cada7a0d0c3d"

--- a/scripts/upgrade.d/upgrade.26.sh
+++ b/scripts/upgrade.d/upgrade.26.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available Nextcloud version
-next_version="27.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="3d312a09b9345ac058758dd7b4059bf3cf0b1f0f1d747251b6fac3585ba6533f"

--- a/scripts/upgrade.d/upgrade.27.sh
+++ b/scripts/upgrade.d/upgrade.27.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available Nextcloud version
-next_version="28.0.0"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="4e8b0b74b40221e85f92ab869d0873c69a52d7e43889d9259c6259428a6a36f2"

--- a/scripts/upgrade.d/upgrade.9.sh
+++ b/scripts/upgrade.d/upgrade.9.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Version cible de la mise à jour de Nextcloud
-next_version="10.0.2"
-
-# Nextcloud tarball checksum
-nextcloud_source_sha256="a687a818778413484f06bb23b4e98589c73729fe2aa9feb1bf5584e3bd37103c"

--- a/scripts/upgrade.d/upgrade.last.sh
+++ b/scripts/upgrade.d/upgrade.last.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Last available Nextcloud version
-next_version="28.0.1"
-
-# Nextcloud tarball checksum sha256
-nextcloud_source_sha256="2f80735b443082272fe6a3b5e32137957f1fc448c75342b94b5200b29725f3a4"


### PR DESCRIPTION
## Problem

- We have to use ugly tricks to create old `app.src` on the fly when we could use the new manifest format
- But we have a shitload versions in `upgrade.d/` and who really believes that upgrading from Nextcloud 15.x still works x_x
- Apparently upgrading from 22.0 did not work because Nextcloud wants to be on 22.2 before upgrading to 23.x

## Solution

- Rework source management using the new source syntax in manifest.toml
- Drop support for versions before 22.2 with a pointer to the appropriate command for folks willing to upgrade to 22.2 first
