### PR TITLE
Modify HSTS Preload policy duration to 1 year

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -55,7 +55,7 @@ location ^~ __PATH__/ {
   client_body_buffer_size 512k;
 
   # HTTP response headers borrowed from Nextcloud `.htaccess`
-  more_set_headers "Strict-Transport-Security: max-age=63072000; includeSubDomains; preload;";
+  more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload;";
   more_set_headers "Referrer-Policy: no-referrer";
   more_set_headers "X-Content-Type-Options: nosniff";
   more_set_headers "X-Download-Options: noopen";

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -55,7 +55,7 @@ location ^~ __PATH__/ {
   client_body_buffer_size 512k;
 
   # HTTP response headers borrowed from Nextcloud `.htaccess`
-  more_set_headers "Strict-Transport-Security: max-age=15768000; includeSubDomains; preload;";
+  more_set_headers "Strict-Transport-Security: max-age=63072000; includeSubDomains; preload;";
   more_set_headers "Referrer-Policy: no-referrer";
   more_set_headers "X-Content-Type-Options: nosniff";
   more_set_headers "X-Download-Options: noopen";


### PR DESCRIPTION
## Problem

*HSTS policy duration is too short* for these reasons : 
- For now the duration of the HSTS policy is set to 6 months which is the minimum duration. It's recommended for more security to have at least 1 year. cf. https://infosec.mozilla.org/guidelines/web_security#http-strict-transport-security
- To add the domain to the HSTS preload list (which is recommended to preload the domain directly in the browser), the duration must be > 1 year cf. https://hstspreload.org/#deployment-recommendations

Sources : 
* https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
* https://datatracker.ietf.org/doc/html/rfc6797

## Solution

- *Set the HSTS policy duration to 1 year*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
