### PR TITLE
move the nextcloud log file to /var/log

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -61,6 +61,12 @@ ynh_backup --src_path="/etc/fail2ban/filter.d/$app.conf"
 ynh_backup --src_path="/etc/cron.d/$app"
 
 #=================================================
+# BACKUP LOGS
+#=================================================
+
+ynh_backup --src_path="/var/log/$app"
+
+#=================================================
 # BACKUP THE MYSQL DATABASE
 #=================================================
 ynh_print_info --message="Backing up the MySQL database..."

--- a/scripts/install
+++ b/scripts/install
@@ -87,6 +87,9 @@ ynh_script_progression --message="Configuring $app..." --weight=8
 # Set the mysql.utf8mb4 config to true in config.php
 exec_occ config:system:set mysql.utf8mb4 --type boolean --value="true"
 
+# move the logs from the data_dir to the standard /var/log
+exec_occ config:system:set logfile --value="/var/log/$app/nextcloud.log"
+
 # Ensure that UpdateNotification app is disabled
 exec_occ app:disable updatenotification
 
@@ -240,7 +243,7 @@ chmod 750 $install_dir
 ynh_script_progression --message="Configuring log rotation..." --weight=1
 
 # Use logrotate to manage application logfile(s)
-ynh_use_logrotate --logfile="$data_dir/data/nextcloud.log"
+ynh_use_logrotate
 
 #=================================================
 # SETUP FAIL2BAN
@@ -248,7 +251,7 @@ ynh_use_logrotate --logfile="$data_dir/data/nextcloud.log"
 ynh_script_progression --message="Configuring Fail2Ban..." --weight=8
 
 # Create a dedicated Fail2Ban config
-ynh_add_fail2ban_config --logpath="$data_dir/data/nextcloud.log" --failregex="^.*Login failed: '.*' \(Remote IP: '<HOST>'.*$" --max_retry=5
+ynh_add_fail2ban_config --logpath="/var/log/$app/nextcloud.log" --failregex="^.*Login failed: '.*' \(Remote IP: '<HOST>'.*$" --max_retry=5
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/remove
+++ b/scripts/remove
@@ -16,6 +16,9 @@ ynh_remove_nginx_config
 # Remove the dedicated PHP-FPM config
 ynh_remove_fpm_config
 
+# remove logs
+ynh_secure_remove --file="/var/log/$app"
+
 # Remove the app-specific logrotate config
 ynh_remove_logrotate
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -54,6 +54,12 @@ ynh_script_progression --message="Restoring cron job..." --weight=1
 ynh_restore_file --origin_path="/etc/cron.d/$app"
 
 #=================================================
+# RESTORE LOGS
+#=================================================
+
+ynh_restore_file --origin_path="/var/log/$app"
+
+#=================================================
 # BACKUP THE LOGROTATE CONFIGURATION
 #=================================================
 ynh_script_progression --message="Restoring the logrotate configuration..." --weight=1
@@ -109,10 +115,10 @@ ynh_restore_file --origin_path="/etc/fail2ban/jail.d/$app.conf"
 ynh_restore_file --origin_path="/etc/fail2ban/filter.d/$app.conf"
 
 # Make sure a log file exists (mostly for CI tests)
-logfile="$data_dir/data/nextcloud.log"
+logfile="/var/log/$app/nextcloud.log"
 if [ ! -f "$logfile" ]; then
 	touch "$logfile"
-	chown $app: "$logfile"
+	chown "$app:" "$logfile"
 fi
 
 ynh_systemd_action --action=restart --service_name=fail2ban

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -346,9 +346,10 @@ fi
 # Create a dedicated NGINX config
 ynh_add_nginx_config
 
-#-------------------------------------------------
+#=================================================
 # CRON JOB
-#-------------------------------------------------
+#=================================================
+
 cron_path="/etc/cron.d/$app"
 ynh_add_config --template="nextcloud.cron" --destination="$cron_path"
 chown root: "$cron_path"
@@ -356,14 +357,15 @@ chmod 644 "$cron_path"
 
 exec_occ background:cron
 
-#-------------------------------------------------
+#=================================================
 # LOGROTATE
-#-------------------------------------------------
+#=================================================
+
 ynh_use_logrotate --non-append
 
-#-------------------------------------------------
+#=================================================
 # FAIL2BAN
-#-------------------------------------------------
+#=================================================
 
 # Create a dedicated Fail2Ban config
 ynh_add_fail2ban_config --logpath="/var/log/$app/nextcloud.log" --failregex="^.*Login failed: '.*' \(Remote IP: '<HOST>'.*$" --max_retry=5

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,6 +24,12 @@ then
     ynh_die --message="Upgrading from Nextcloud < 22.2 is not supported anymore. You should first upgrade to 22.2 using: yunohost app upgrade nextcloud -u https://github.com/YunoHost-Apps/nextcloud_ynh/tree/41f5f902e7c7cd3c30a6793020562ba98b9bf3e9"
 fi
 
+# move the logs from the data_dir to the standard /var/log
+if [ -f "$data_dir/data/nextcloud.log" ]; then
+    mv "$data_dir"/data/nextcloud.log* "/var/log/$app"
+    # adapt the nextcloud config
+    exec_occ config:system:set logfile --value="/var/log/$app/nextcloud.log"
+fi
 
 #=================================================
 # SPECIFIC UPGRADE
@@ -360,7 +366,7 @@ ynh_use_logrotate --non-append
 #-------------------------------------------------
 
 # Create a dedicated Fail2Ban config
-ynh_add_fail2ban_config --logpath="$data_dir/data/nextcloud.log" --failregex="^.*Login failed: '.*' \(Remote IP: '<HOST>'.*$" --max_retry=5
+ynh_add_fail2ban_config --logpath="/var/log/$app/nextcloud.log" --failregex="^.*Login failed: '.*' \(Remote IP: '<HOST>'.*$" --max_retry=5
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,13 +24,6 @@ then
     ynh_die --message="Upgrading from Nextcloud < 22.2 is not supported anymore. You should first upgrade to 22.2 using: yunohost app upgrade nextcloud -u https://github.com/YunoHost-Apps/nextcloud_ynh/tree/41f5f902e7c7cd3c30a6793020562ba98b9bf3e9"
 fi
 
-# move the logs from the data_dir to the standard /var/log
-if [ -f "$data_dir/data/nextcloud.log" ]; then
-    mv "$data_dir"/data/nextcloud.log* "/var/log/$app"
-    # adapt the nextcloud config
-    exec_occ config:system:set logfile --value="/var/log/$app/nextcloud.log"
-fi
-
 #=================================================
 # SPECIFIC UPGRADE
 #=================================================
@@ -244,6 +237,15 @@ then
 
     # Update all installed apps
     exec_occ app:update --all
+
+    # move the logs from the data_dir to the standard /var/log
+    # it would be better in the ENSURE DOWNWARD COMPATIBILITY section
+    # but it must be after the exec_occ() definition, so it's here
+    if [ -f "$data_dir/data/nextcloud.log" ]; then
+        mv "$data_dir"/data/nextcloud.log* "/var/log/$app"
+        # adapt the nextcloud config
+        exec_occ config:system:set logfile --value="/var/log/$app/nextcloud.log"
+    fi
 
     # Load the config file in nextcloud
     exec_occ config:import "$nc_conf"


### PR DESCRIPTION
## Problem

- people absolutely wants to edit the fail2ban config because they moved their data_dir elsewhere
see: https://github.com/YunoHost/doc/pull/2415 https://github.com/YunoHost/doc/pull/2416

## Solution

- move the log file to `/var/log`, where it belongs, so no need to change that damn fail2ban file at all 😓

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
