### PR TITLE
Fix upgrade tmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ In addition to Nextcloud core features, the following are made available with th
  * Optionally access the user home folder from Nextcloud files (set at the installation, the sharing is enabled by default)
  * Serve `/.well-known` paths for CalDAV and CardDAV on the domain only if it's not already served - i.e. by Baïkal
 
-
 **Shipped version:** 28.0.3~ynh2
 
-**Demo:** https://demo.nextcloud.com/
+**Demo:** <https://demo.nextcloud.com/>
 
 ## Screenshots
 
@@ -39,12 +38,12 @@ In addition to Nextcloud core features, the following are made available with th
 
 ## Documentation and resources
 
-* Official app website: <https://nextcloud.com>
-* Official user documentation: <https://docs.nextcloud.com/server/latest/user_manual/en/>
-* Official admin documentation: <https://docs.nextcloud.com/server/stable/admin_manual/>
-* Upstream app code repository: <https://github.com/nextcloud/server>
-* YunoHost Store: <https://apps.yunohost.org/app/nextcloud>
-* Report a bug: <https://github.com/YunoHost-Apps/nextcloud_ynh/issues>
+- Official app website: <https://nextcloud.com>
+- Official user documentation: <https://docs.nextcloud.com/server/latest/user_manual/en/>
+- Official admin documentation: <https://docs.nextcloud.com/server/stable/admin_manual/>
+- Upstream app code repository: <https://github.com/nextcloud/server>
+- YunoHost Store: <https://apps.yunohost.org/app/nextcloud>
+- Report a bug: <https://github.com/YunoHost-Apps/nextcloud_ynh/issues>
 
 ## Developer info
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -28,10 +28,9 @@ En plus des fonctionnalités principales de Nextcloud, les fonctionnalités suiv
  * Accès optionnel au répertoire home depuis les fichiers Nextcloud (à activer à l'installation, le partage étant activé par défaut)
  * Utilise l'adresse `/.well-known` pour la synchronisation CalDAV et CardDAV du domaine si aucun autre service ne l'utilise déjà - par exemple, Baïkal
 
-
 **Version incluse :** 28.0.3~ynh2
 
-**Démo :** https://demo.nextcloud.com/
+**Démo :** <https://demo.nextcloud.com/>
 
 ## Captures d’écran
 
@@ -39,12 +38,12 @@ En plus des fonctionnalités principales de Nextcloud, les fonctionnalités suiv
 
 ## Documentations et ressources
 
-* Site officiel de l’app : <https://nextcloud.com>
-* Documentation officielle utilisateur : <https://docs.nextcloud.com/server/latest/user_manual/en/>
-* Documentation officielle de l’admin : <https://docs.nextcloud.com/server/stable/admin_manual/>
-* Dépôt de code officiel de l’app : <https://github.com/nextcloud/server>
-* YunoHost Store: <https://apps.yunohost.org/app/nextcloud>
-* Signaler un bug : <https://github.com/YunoHost-Apps/nextcloud_ynh/issues>
+- Site officiel de l’app : <https://nextcloud.com>
+- Documentation officielle utilisateur : <https://docs.nextcloud.com/server/latest/user_manual/en/>
+- Documentation officielle de l’admin : <https://docs.nextcloud.com/server/stable/admin_manual/>
+- Dépôt de code officiel de l’app : <https://github.com/nextcloud/server>
+- YunoHost Store : <https://apps.yunohost.org/app/nextcloud>
+- Signaler un bug : <https://github.com/YunoHost-Apps/nextcloud_ynh/issues>
 
 ## Informations pour les développeurs
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -41,44 +41,5 @@ is_url_handled() {
 }
 
 #=================================================
-
-# Check available space before creating a temp directory.
-#
-# usage: ynh_smart_mktemp --min_size="Min size"
-#
-# | arg: -s, --min_size= - Minimal size needed for the temporary directory, in Mb
-ynh_smart_mktemp () {
-        # Declare an array to define the options of this helper.
-        declare -Ar args_array=( [s]=min_size= )
-        local min_size
-        # Manage arguments with getopts
-        ynh_handle_getopts_args "$@"
-
-        min_size="${min_size:-300}"
-        # Transform the minimum size from megabytes to kilobytes
-        min_size=$(( $min_size * 1024 ))
-
-        # Check if there's enough free space in a directory
-        is_there_enough_space () {
-                local free_space=$(df --output=avail "$1" | sed 1d)
-                test $free_space -ge $min_size
-        }
-
-        if is_there_enough_space /tmp; then
-                local tmpdir=/tmp
-        elif is_there_enough_space /var; then
-                local tmpdir=/var
-        elif is_there_enough_space /; then
-                local tmpdir=/
-        elif is_there_enough_space /home; then
-                local tmpdir=/home
-        else
-                ynh_die "Insufficient free space to continue..."
-        fi
-
-        echo "$(mktemp --directory --tmpdir="$tmpdir")"
-}
-
-#=================================================
 # FUTURE OFFICIAL HELPERS
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -164,7 +164,7 @@ then
         fi
 
         # Create a temporary directory
-        tmpdir="$(ynh_smart_mktemp min_size=300)"
+        tmpdir="${install_dir}__tmp_upgrade"
 
         ynh_setup_source --dest_dir="$tmpdir" --source_id="$source_id"
 


### PR DESCRIPTION
## Problem

`ynh_smart_mktemp min_size=300` is not enough for me. some apps are huge, my current install_dir is 1.6GB, and my /tmp is 1.4GB free only.

## Solution

The best way to ensure there is enough disk space is to use a temporary directory just next to the install_dir.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
