### PR TITLE
fix nginx config

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -19,7 +19,7 @@ location ^~ /.well-known {
   location = /.well-known/caldav      { return 301 __PATH__/remote.php/dav/; }
 
   location = /.well-known/webfinger     { return 301 __PATH__/index.php$request_uri; }
-  location = /.well-known/nodeinfo      { return 301 __PATH__/index.php$uri; }
+  location = /.well-known/nodeinfo      { return 301 __PATH__/index.php$request_uri; }
 
   # Let Nextcloud's API for `/.well-known` URIs handle all other
   # requests by passing them to the front-end controller.


### PR DESCRIPTION
## Problem

1. found a small security issue running [gixy](https://github.com/yandex/gixy) against a server of mine

```bash
>> Problem: [http_splitting] Possible HTTP-Splitting vulnerability.
Description: Using variables that can contain "\n" or "\r" may lead to http injection.
Additional info: https://github.com/yandex/gixy/blob/master/docs/en/plugins/httpsplitting.md
Reason: At least variable "$uri" can contain "\n"
Pseudo config:

include /etc/nginx/conf.d/nextcloud.server.com.conf;

	server {
		server_name nextcloud.server.com;

		include /etc/nginx/conf.d/nextcloud.server.com.d/nextcloud.conf;

			location ^~ /.well-known {

				location = /.well-known/nodeinfo {
					return 301 /index.php$uri;
				}
			}
	}
```


## Solution

- fix it issuing the same config as the `webfinger` item
- It "might" even possible to remove these two lines https://github.com/nextcloud/documentation/pull/8007#pullrequestreview-948372670
  - I didn't find easy information on these endpoints. A [PR is open](https://github.com/nextcloud/documentation/pull/6311) to 1. add it to the nextcloud admin documentation and 2. decide what to do about the nginx config one the doc is there.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
  - [x] gixy does not complain anymore
  - [x] nextcloud is still there

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
