### PR TITLE
Fix space splitting in phpflags on install

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -6,7 +6,7 @@ source _ynh_mysql_connect_as.sh
 
 phpflags="--define apc.enable_cli=1"
 
-ynh_app_setting_set --app=$app --key=phpflags --value=$phpflags
+ynh_app_setting_set --app=$app --key=phpflags --value="$phpflags"
 
 #=================================================
 # CREATE A MYSQL DATABASE


### PR DESCRIPTION
## Problem

`phpflags` ends up being `--define;apc.enable_cli=1` because of space splitting. I did not investigate why it breaks in this exact way, something inside `ynh_app_setting_set`. Because of this `php occ` in `yunohost app shell` does not work.

## Solution

- Use quotes to prevent space splitting.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
