### PR TITLE
Fix upgrade: php version is 8.3 starting from 29.x ?

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -39,7 +39,10 @@ filter_boring_occ_warnings() {
 # Define a function to execute commands with `occ`
 exec_occ() {
     # Backward compatibility to upgrade from older versions
-    if [ $current_major_version = "last" ] || [ $current_major_version -ge 26 ]
+    if [ $current_major_version = "last" ]
+    then
+        NEXTCLOUD_PHP_VERSION="8.3"
+    elif [ $current_major_version -ge 26 ]
     then
         NEXTCLOUD_PHP_VERSION="8.2"
     elif [ $current_major_version -ge 24 ]


### PR DESCRIPTION
I'm not sure anymore about the context but this sounds important for smooth upgrades through multiple versions