### PR TITLE
Avoid chown data_dir during the upgrade process

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -3,13 +3,18 @@ version = "1.0"
 [main]
 name = "Nextcloud configuration"
 
-    [main.maintenance_mode]
-    name = "Maintenance mode"
+    [main.maintenance]
+    name = "Maintenance"
 
-        [main.maintenance_mode.maintenance_mode]
+        [main.maintenance.maintenance_mode]
         ask = "Enable maintenance mode"
         type = "boolean"
         default = "0"
+
+        [main.maintenance.set_permissions_button]
+        ask.en = "Set permissions for all data (Can take up to several hours if users have a lot of data)"
+        type = "button"
+        style = "success"
 
     [main.addressbook]
     name = "Address book configuration"

--- a/scripts/config
+++ b/scripts/config
@@ -106,6 +106,24 @@ set__fpm_free_footprint() {
 }
 
 #=================================================
+# SPECIFIC RUNNERS FOR TOML SHORT KEYS
+#=================================================
+
+function run__set_permissions_button() {
+    local data_dir=$(ynh_app_setting_get --app=$app --key=data_dir)
+    ynh_print_info "Set permissions, it may take some time..."
+    chown -R $app:www-data "$install_dir"
+    chown -R $app: "$data_dir"
+    find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
+    find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
+    find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640
+    find $data_dir/data/ -type d -print0 | xargs -r0 chmod 0750
+    chmod 640 "$install_dir/config/config.php"
+    chmod 755 /home/yunohost.app
+    chmod 750 $install_dir
+}
+
+#=================================================
 # GENERIC FINALIZATION
 #=================================================
 

--- a/scripts/install
+++ b/scripts/install
@@ -64,10 +64,8 @@ exec_occ() {
 }
 
 # Set write access for the following commands
-find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
-chown $app:www-data "$install_dir"
-find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
-chown $app: "$data_dir"
+find "$install_dir" -not \( -user $app -and -group www-data \) -exec chown $app:www-data {} \+
+find "$data_dir" -not \( -user $app -and -group $app \) -exec chown $app: {} \+
 
 # Define password in an intermediate var
 # The fact that it's called _password allows it to be
@@ -237,10 +235,8 @@ ynh_multimedia_addaccess $app
 #=================================================
 
 # Fix app ownerships & permissions
-find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
-chown $app:www-data "$install_dir"
-find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
-chown $app: "$data_dir"
+find "$install_dir" -not \( -user $app -and -group www-data \) -exec chown $app:www-data {} \+
+find "$data_dir" -not \( -user $app -and -group $app \) -exec chown $app: {} \+
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640

--- a/scripts/install
+++ b/scripts/install
@@ -64,7 +64,8 @@ exec_occ() {
 }
 
 # Set write access for the following commands
-chown -R $app: "$install_dir" "$data_dir"
+find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
+find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
 
 # Define password in an intermediate var
 # The fact that it's called _password allows it to be
@@ -234,8 +235,8 @@ ynh_multimedia_addaccess $app
 #=================================================
 
 # Fix app ownerships & permissions
-chown -R $app:www-data "$install_dir"
-chown -R $app: "$data_dir"
+find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
+find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640

--- a/scripts/install
+++ b/scripts/install
@@ -65,6 +65,7 @@ exec_occ() {
 
 # Set write access for the following commands
 chown -R $app:www-data "$install_dir"
+chmod 600 "$install_dir/config/config.php"
 chown -R $app: "$data_dir"
 
 # Define password in an intermediate var
@@ -241,7 +242,7 @@ find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640
 find $data_dir/data/ -type d -print0 | xargs -r0 chmod 0750
-chmod 640 "$install_dir/config/config.php"
+chmod 600 "$install_dir/config/config.php"
 chmod 755 /home/yunohost.app
 chmod 750 $install_dir
 

--- a/scripts/install
+++ b/scripts/install
@@ -65,7 +65,6 @@ exec_occ() {
 
 # Set write access for the following commands
 chown -R $app:www-data "$install_dir"
-chmod 600 "$install_dir/config/config.php"
 chown -R $app: "$data_dir"
 
 # Define password in an intermediate var

--- a/scripts/install
+++ b/scripts/install
@@ -64,8 +64,8 @@ exec_occ() {
 }
 
 # Set write access for the following commands
-find "$install_dir" -not \( -user $app -and -group www-data \) -exec chown $app:www-data {} \+
-find "$data_dir" -not \( -user $app -and -group $app \) -exec chown $app: {} \+
+chown -R $app:www-data "$install_dir"
+chown -R $app: "$data_dir"
 
 # Define password in an intermediate var
 # The fact that it's called _password allows it to be
@@ -235,8 +235,8 @@ ynh_multimedia_addaccess $app
 #=================================================
 
 # Fix app ownerships & permissions
-find "$install_dir" -not \( -user $app -and -group www-data \) -exec chown $app:www-data {} \+
-find "$data_dir" -not \( -user $app -and -group $app \) -exec chown $app: {} \+
+chown -R $app:www-data "$install_dir"
+chown -R $app: "$data_dir"
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640

--- a/scripts/install
+++ b/scripts/install
@@ -65,7 +65,9 @@ exec_occ() {
 
 # Set write access for the following commands
 find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
+chown $app:www-data "$install_dir"
 find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
+chown $app: "$data_dir"
 
 # Define password in an intermediate var
 # The fact that it's called _password allows it to be
@@ -236,7 +238,9 @@ ynh_multimedia_addaccess $app
 
 # Fix app ownerships & permissions
 find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
+chown $app:www-data "$install_dir"
 find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
+chown $app: "$data_dir"
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640

--- a/scripts/restore
+++ b/scripts/restore
@@ -85,7 +85,7 @@ find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640
 find $data_dir/data/ -type d -print0 | xargs -r0 chmod 0750
-chmod 640 "$install_dir/config/config.php"
+chmod 600 "$install_dir/config/config.php"
 chmod 755 /home/yunohost.app
 chmod 750 $install_dir
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -79,8 +79,8 @@ ynh_restore_file --origin_path="$data_dir" --not_mandatory
 #=================================================
 
 # Fix app ownerships & permissions
-find "$install_dir" -not \( -user $app -and -group www-data \) -exec chown $app:www-data {} \+
-find "$data_dir" -not \( -user $app -and -group $app \) -exec chown $app: {} \+
+chown -R $app:www-data "$install_dir"
+chown -R $app: "$data_dir"
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640

--- a/scripts/restore
+++ b/scripts/restore
@@ -79,10 +79,8 @@ ynh_restore_file --origin_path="$data_dir" --not_mandatory
 #=================================================
 
 # Fix app ownerships & permissions
-find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
-chown $app:www-data "$install_dir"
-find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
-chown $app: "$data_dir"
+find "$install_dir" -not \( -user $app -and -group www-data \) -exec chown $app:www-data {} \+
+find "$data_dir" -not \( -user $app -and -group $app \) -exec chown $app: {} \+
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640

--- a/scripts/restore
+++ b/scripts/restore
@@ -79,8 +79,8 @@ ynh_restore_file --origin_path="$data_dir" --not_mandatory
 #=================================================
 
 # Fix app ownerships & permissions
-chown -R $app:www-data "$install_dir"
-chown -R $app: "$data_dir"
+find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
+find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640

--- a/scripts/restore
+++ b/scripts/restore
@@ -80,7 +80,9 @@ ynh_restore_file --origin_path="$data_dir" --not_mandatory
 
 # Fix app ownerships & permissions
 find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
+chown $app:www-data "$install_dir"
 find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
+chown $app: "$data_dir"
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -138,8 +138,7 @@ then
     ynh_script_progression --message="Upgrading $app..." --weight=3
 
     # Set write access for the following commands
-    find "$install_dir" -not \( -user $app -and -group www-data \) -exec chown $app:www-data {} \+
-    find "$data_dir" -not \( -user $app -and -group $app \) -exec chown $app: {} \+
+    chown -R $app:www-data "$install_dir"
 
     # Print the current version number of Nextcloud
     exec_occ -V
@@ -208,8 +207,7 @@ then
         mv "$tmpdir" "$install_dir"
 
         # Set write access for the following commands
-        find "$install_dir" -not \( -user $app -and -group www-data \) -exec chown $app:www-data {} \+
-        find "$data_dir" -not \( -user $app -and -group $app \) -exec chown $app: {} \+
+        chown -R $app:www-data "$install_dir"
 
         # Upgrade Nextcloud (SUCCESS = 0, UP_TO_DATE = 3)
         exec_occ maintenance:mode --off
@@ -326,8 +324,7 @@ fi
 ynh_script_progression --message="Reapplying file permissions..." --weight=2
 
 # Fix app ownerships & permissions
-find "$install_dir" -not \( -user $app -and -group www-data \) -exec chown $app:www-data {} \+
-find "$data_dir" -not \( -user $app -and -group $app \) -exec chown $app: {} \+
+chown -R $app:www-data "$install_dir"
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -138,7 +138,8 @@ then
     ynh_script_progression --message="Upgrading $app..." --weight=3
 
     # Set write access for the following commands
-    chown -R $app: "$install_dir" "$data_dir"
+    find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
+    find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
 
     # Print the current version number of Nextcloud
     exec_occ -V
@@ -207,7 +208,8 @@ then
         mv "$tmpdir" "$install_dir"
 
         # Set write access for the following commands
-        chown -R $app: "$install_dir" "$data_dir"
+        find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
+        find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
 
         # Upgrade Nextcloud (SUCCESS = 0, UP_TO_DATE = 3)
         exec_occ maintenance:mode --off
@@ -324,8 +326,8 @@ fi
 ynh_script_progression --message="Reapplying file permissions..." --weight=2
 
 # Fix app ownerships & permissions
-chown -R $app:www-data "$install_dir"
-chown -R $app: "$data_dir"
+find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
+find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -139,7 +139,9 @@ then
 
     # Set write access for the following commands
     find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
+    chown $app:www-data "$install_dir"
     find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
+    chown $app: "$data_dir"
 
     # Print the current version number of Nextcloud
     exec_occ -V
@@ -209,7 +211,9 @@ then
 
         # Set write access for the following commands
         find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
+        chown $app:www-data "$install_dir"
         find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
+        chown $app: "$data_dir"
 
         # Upgrade Nextcloud (SUCCESS = 0, UP_TO_DATE = 3)
         exec_occ maintenance:mode --off
@@ -327,7 +331,9 @@ ynh_script_progression --message="Reapplying file permissions..." --weight=2
 
 # Fix app ownerships & permissions
 find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
+chown $app:www-data "$install_dir"
 find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
+chown $app: "$data_dir"
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -327,8 +327,6 @@ ynh_script_progression --message="Reapplying file permissions..." --weight=2
 chown -R $app:www-data "$install_dir"
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
-find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640
-find $data_dir/data/ -type d -print0 | xargs -r0 chmod 0750
 chmod 640 "$install_dir/config/config.php"
 chmod 755 /home/yunohost.app
 chmod 750 $install_dir

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -139,7 +139,6 @@ then
 
     # Set write access for the following commands
     chown -R $app:www-data "$install_dir"
-    chmod 600 "$install_dir/config/config.php"
 
     # Print the current version number of Nextcloud
     exec_occ -V
@@ -209,7 +208,6 @@ then
 
         # Set write access for the following commands
         chown -R $app:www-data "$install_dir"
-        chmod 600 "$install_dir/config/config.php"
 
         # Upgrade Nextcloud (SUCCESS = 0, UP_TO_DATE = 3)
         exec_occ maintenance:mode --off

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -139,6 +139,7 @@ then
 
     # Set write access for the following commands
     chown -R $app:www-data "$install_dir"
+    chmod 600 "$install_dir/config/config.php"
 
     # Print the current version number of Nextcloud
     exec_occ -V
@@ -208,6 +209,7 @@ then
 
         # Set write access for the following commands
         chown -R $app:www-data "$install_dir"
+        chmod 600 "$install_dir/config/config.php"
 
         # Upgrade Nextcloud (SUCCESS = 0, UP_TO_DATE = 3)
         exec_occ maintenance:mode --off
@@ -327,7 +329,7 @@ ynh_script_progression --message="Reapplying file permissions..." --weight=2
 chown -R $app:www-data "$install_dir"
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
-chmod 640 "$install_dir/config/config.php"
+chmod 600 "$install_dir/config/config.php"
 chmod 755 /home/yunohost.app
 chmod 750 $install_dir
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -138,10 +138,8 @@ then
     ynh_script_progression --message="Upgrading $app..." --weight=3
 
     # Set write access for the following commands
-    find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
-    chown $app:www-data "$install_dir"
-    find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
-    chown $app: "$data_dir"
+    find "$install_dir" -not \( -user $app -and -group www-data \) -exec chown $app:www-data {} \+
+    find "$data_dir" -not \( -user $app -and -group $app \) -exec chown $app: {} \+
 
     # Print the current version number of Nextcloud
     exec_occ -V
@@ -210,10 +208,8 @@ then
         mv "$tmpdir" "$install_dir"
 
         # Set write access for the following commands
-        find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
-        chown $app:www-data "$install_dir"
-        find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
-        chown $app: "$data_dir"
+        find "$install_dir" -not \( -user $app -and -group www-data \) -exec chown $app:www-data {} \+
+        find "$data_dir" -not \( -user $app -and -group $app \) -exec chown $app: {} \+
 
         # Upgrade Nextcloud (SUCCESS = 0, UP_TO_DATE = 3)
         exec_occ maintenance:mode --off
@@ -330,10 +326,8 @@ fi
 ynh_script_progression --message="Reapplying file permissions..." --weight=2
 
 # Fix app ownerships & permissions
-find "$install_dir" -not \( -user $app -or -group www-data \) -exec chown $app:www-data {} \+
-chown $app:www-data "$install_dir"
-find "$data_dir" -not \( -user $app -or -group $app \) -exec chown $app: {} \+
-chown $app: "$data_dir"
+find "$install_dir" -not \( -user $app -and -group www-data \) -exec chown $app:www-data {} \+
+find "$data_dir" -not \( -user $app -and -group $app \) -exec chown $app: {} \+
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
 find $data_dir/data/ -type f -print0 | xargs -r0 chmod 0640


### PR DESCRIPTION
## Problem

- *chown the world*

## Solution

- *don't chown/chmod data_dir and his content during the upgrade*
- *add a button in the config panel to launch the corresponding chown/chmod command (this my fix issue in some case I guess?)*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
