### PR TITLE
Fix removing ACL permissions on uninstall

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -30,7 +30,7 @@ ynh_secure_remove --file="/etc/cron.d/$app"
 for i in $(ls /home); do
   # Clean ACL in every directories in /home, except those which start with 'yunohost.'
   [[ ! $i == yunohost.* ]] \
-    && setfacl --remove g:$app:rwx 2>&1
+    && setfacl --remove g:$app 2>&1
 done
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -27,10 +27,10 @@ ynh_remove_fail2ban_config
 ynh_secure_remove --file="/etc/cron.d/$app"
 
 # Cleaning ACL in home directories
-for i in $(ls /home); do
+for path in /home/*; do
   # Clean ACL in every directories in /home, except those which start with 'yunohost.'
-  [[ ! $i == yunohost.* ]] \
-    && setfacl --remove g:$app -- "$i" 2>&1
+  [[ ! $path == /home/yunohost.* ]] \
+    && setfacl --remove g:$app -- "$path" 2>&1
 done
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -30,7 +30,7 @@ ynh_secure_remove --file="/etc/cron.d/$app"
 for i in $(ls /home); do
   # Clean ACL in every directories in /home, except those which start with 'yunohost.'
   [[ ! $i == yunohost.* ]] \
-    && setfacl --remove g:$app 2>&1
+    && setfacl --remove g:$app -- "$i" 2>&1
 done
 
 #=================================================


### PR DESCRIPTION
## Problem

The `remove` script fails to remove the ACL permissions for the home directory:

```
  - 2024-08-13 20:04:31,527: DEBUG - + setfacl --remove g:nextcloud__2:rwx
  - 2024-08-13 20:04:31,528: DEBUG - setfacl: Option -x: Invalid argument near character 16
```

This leaves the permissions open for the next app that happens to get assigned the UID of the previous NextCloud installation.

## Solution

According to `man setfacl`, for the `--remove`  option "[o]nly ACL entries without the perms field are accepted as parameters".

- I removed the "perms" field (the `:rwx` part) from the `setfacl --remove` call since it is not necessary to specify the permissions, when they should be removed anyways.
- I added the path to the directory for which the permissions should be removed
- I changed the `for` loop from `ls` to glob pattern to prevent issues with spaces

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

~~I'm completely new to YunoHost so I don't know how I would test this other than executing the command directly in the shell and checking that the ACL permissions were removed.~~    
I managed to test it and it works :)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
