### PR TITLE
Remove ~duplicate pre-upgrade message

### DIFF
--- a/doc/PRE_UPGRADE.d/28.0.3~ynh1.md
+++ b/doc/PRE_UPGRADE.d/28.0.3~ynh1.md
@@ -1,3 +1,0 @@
-If you are upgrading to a new major version of Nextcloud, please make sure that your Nextcloud apps are up to date from Nextcloud's administration panel beforehand.
-
-Additionally, if you installed specific Nextcloud apps, we recommend making sure that they are compatible with the new major version. YunoHost will attempt to check this automatically at the very beginning of the upgrade, but a manual check doesn't hurt either. For Nextcloud 28, this forum thread might be helpful : <https://help.nextcloud.com/t/apps-not-compatible-with-nc-28/176234>.


### PR DESCRIPTION
## Problem

When upgrading from versions prior to 28.x, both pre-upgrade messages for 28.x and 29.x are displayed, despite them telling basically the same thing. User only need to see the last one imho

## Solution

Get rid of the 28.x pre-upgrade message
