### PR TITLE
Patch 4

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Nextcloud"
 description.en = "Online storage, file sharing platform and various other applications"
 description.fr = "Stockage en ligne, plateforme de partage de fichiers et diverses autres applications"
 
-version = "28.0.6~ynh1"
+version = "28.0.10~ynh1"
 
 maintainers = ["kay0u"]
 
@@ -66,7 +66,7 @@ ram.runtime = "512M"
     [resources.sources]
 
         [resources.sources.main]
-        url = 'https://download.nextcloud.com/server/releases/nextcloud-28.0.6.tar.bz2'
+        url = 'https://download.nextcloud.com/server/releases/nextcloud-28.0.10.tar.bz2'
         sha256 = 'df0d3384b447cba1e128f22080f6780521f868169beabee8ea0d155bf9c66b8f'
 
         [resources.sources.27]

--- a/manifest.toml
+++ b/manifest.toml
@@ -67,7 +67,7 @@ ram.runtime = "512M"
 
         [resources.sources.main]
         url = 'https://download.nextcloud.com/server/releases/nextcloud-28.0.10.tar.bz2'
-        sha256 = 'df0d3384b447cba1e128f22080f6780521f868169beabee8ea0d155bf9c66b8f'
+        sha256 = '2e801526d2891c185feac5985cbd3ce292ce70a425f536f919f901b9fb4cc210'
 
         [resources.sources.27]
         url = 'https://download.nextcloud.com/server/releases/nextcloud-27.0.0.tar.bz2'

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -262,7 +262,9 @@ then
     # Add dynamic logout URL to the config
     url_base64="$(echo -n "https://$domain$path" | base64)"
     old_logout_url="https://$(cat /etc/yunohost/current_host)/yunohost/sso/?action=logout"
+    set +e
     current_logout_url="$(exec_occ config:system:get logout_url 2> /dev/null)"
+    set -e
     if [[ "$current_logout_url" == "${old_logout_url}" ]] || [[ "$current_logout_url" == "" ]]
     then
         echo "


### PR DESCRIPTION
## Problem

- *version 28.0.6 is oudated*

## Solution

- *get last 28.0.10 release*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
