### PR TITLE
Fixed backup

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Nextcloud"
 description.en = "Online storage, file sharing platform and various other applications"
 description.fr = "Stockage en ligne, plateforme de partage de fichiers et diverses autres applications"
 
-version = "29.0.7~ynh1"
+version = "29.0.7~ynh2"
 
 maintainers = ["kay0u"]
 

--- a/scripts/backup
+++ b/scripts/backup
@@ -41,9 +41,6 @@ ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.d"
 # Backup the PHP-FPM configuration
 ynh_backup --src_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 
-# Backup the nginx configuration
-ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
-
 # Backup the logrotate configuration
 ynh_backup --src_path="/etc/logrotate.d/$app"
 


### PR DESCRIPTION
## Problem

- Backup fails for mont-requiring methods (i.e. borg)

## Solution

- `nginx/nextcloud.conf` is declared twice x_x

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
