### PR TITLE
Forward Email?

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -52,7 +52,7 @@ name.fr = "Configuration de Nextcloud"
     name.fr = "E-mails de transfert?"
 
         [main.forward_email.enable_forward_email]
-        ask.en = "Set yunohost user's forward email instead of yunohost user's main email?"
+        ask.en = "Set YunoHost user's forward email instead of YunoHost user's main email?"
         ask.fr = "Utiliser les emails de transfert des utilisateurs de yunohost plutôt que les emails principaux ?"
         type = "boolean"
         help.en = "If all your users have set a forward email and aren't using yunohost emails, you may choose to set their forward email as their nextcloud email setting."

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -56,7 +56,7 @@ name.fr = "Configuration de Nextcloud"
         ask.fr = "Utiliser les e-mails de transfert des utilisateurs de YunoHost plutôt que les e-mails principaux ?"
         type = "boolean"
         help.en = "If all your users have set a forward email and aren't using YunoHost emails, you may choose to set their forward email as their Nextcloud email setting."
-        help.fr = "Si tous vos utilisateurs ont paramétré un email de transfert et n'utilise pas du tout les emails de leur compte yunohost, vous pouvez paramétrer nextcloud d'utiliser les emails de transfert."
+        help.fr = "Si tous vos utilisateurs ont paramétré un e-mail de transfert et n'utilise pas du tout les e-mails de leur compte YunoHost, vous pouvez paramétrer Nextcloud d'utiliser les e-mails de transfert."
 
     [main.php_fpm_config]
     name.en = "PHP-FPM configuration"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -53,7 +53,7 @@ name.fr = "Configuration de Nextcloud"
 
         [main.forward_email.enable_forward_email]
         ask.en = "Set YunoHost user's forward email instead of YunoHost user's main email?"
-        ask.fr = "Utiliser les emails de transfert des utilisateurs de yunohost plutôt que les emails principaux ?"
+        ask.fr = "Utiliser les e-mails de transfert des utilisateurs de YunoHost plutôt que les e-mails principaux ?"
         type = "boolean"
         help.en = "If all your users have set a forward email and aren't using yunohost emails, you may choose to set their forward email as their nextcloud email setting."
         help.fr = "Si tous vos utilisateurs ont paramétré un email de transfert et n'utilise pas du tout les emails de leur compte yunohost, vous pouvez paramétrer nextcloud d'utiliser les emails de transfert."

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -49,7 +49,7 @@ name.fr = "Configuration de Nextcloud"
 
     [main.forward_email]
     name.en = "Forward Email?"
-    name.fr = "Emails de transfert?"
+    name.fr = "E-mails de transfert?"
 
         [main.forward_email.enable_forward_email]
         ask.en = "Set yunohost user's forward email instead of yunohost user's main email?"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -47,6 +47,17 @@ name.fr = "Configuration de Nextcloud"
         help.en = "<a href=https://github.com/nextcloud/notify_push#about target=_blank>Notify Push</a> is a mechanism  allowing more instantaneous notifications and reduce server load."
         help.fr = "<a href=https://github.com/nextcloud/notify_push#about target=_blank>Notify Push</a> est un mécanisme qui permet d'avoir des notifications plus rapides et de réduire la charge du serveur."
 
+    [main.forward_email]
+    name.en = "Forward Email?"
+    name.fr = "Emails de transfert?"
+
+        [main.forward_email.enable_forward_email]
+        ask.en = "Set yunohost user's forward email instead of yunohost user's main email?"
+        ask.fr = "Utiliser les emails de transfert des utilisateurs de yunohost plutôt que les emails principaux ?"
+        type = "boolean"
+        help.en = "If all your users have set a forward email and aren't using yunohost emails, you may choose to set their forward email as their nextcloud email setting."
+        help.fr = "Si tous vos utilisateurs ont paramétré un email de transfert et n'utilise pas du tout les emails de leur compte yunohost, vous pouvez paramétrer nextcloud d'utiliser les emails de transfert."
+
     [main.php_fpm_config]
     name.en = "PHP-FPM configuration"
     name.fr = "Configuration de PHP-FPM"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -55,7 +55,7 @@ name.fr = "Configuration de Nextcloud"
         ask.en = "Set YunoHost user's forward email instead of YunoHost user's main email?"
         ask.fr = "Utiliser les e-mails de transfert des utilisateurs de YunoHost plutôt que les e-mails principaux ?"
         type = "boolean"
-        help.en = "If all your users have set a forward email and aren't using yunohost emails, you may choose to set their forward email as their nextcloud email setting."
+        help.en = "If all your users have set a forward email and aren't using YunoHost emails, you may choose to set their forward email as their Nextcloud email setting."
         help.fr = "Si tous vos utilisateurs ont paramétré un email de transfert et n'utilise pas du tout les emails de leur compte yunohost, vous pouvez paramétrer nextcloud d'utiliser les emails de transfert."
 
     [main.php_fpm_config]

--- a/scripts/config
+++ b/scripts/config
@@ -48,7 +48,7 @@ get__system_addressbook_exposed() {
 }
 
 get__enable_forward_email() {
-    ldapEmail=$(exec_occ ldap:show-config | grep ldapEmailAttribute)
+    ldapEmail=$(exec_occ ldap:show-config "" | grep ldapEmailAttribute)
     if [ $(echo $ldapEmail | grep -Po "maildrop") = "maildrop" ]
     then
         echo "1"

--- a/scripts/config
+++ b/scripts/config
@@ -49,7 +49,7 @@ get__system_addressbook_exposed() {
 
 get__enable_forward_email() {
     ldapEmail=$(exec_occ ldap:show-config "" | grep ldapEmailAttribute)
-    if [ $(echo $ldapEmail | grep -Po "maildrop") = "maildrop" ]
+    if [ "$(echo $ldapEmail | grep -Po "maildrop")" = "maildrop" ]
     then
         echo "1"
     else

--- a/scripts/config
+++ b/scripts/config
@@ -47,6 +47,16 @@ get__system_addressbook_exposed() {
 	echo $(exec_occ config:app:get dav system_addressbook_exposed)
 }
 
+get__enable_forward_email() {
+    ldapEmail=$(exec_occ ldap:show-config | grep ldapEmailAttribute)
+    if [ $(echo $ldapEmail | grep -Po "maildrop") = "maildrop" ]
+    then
+        echo "1"
+    else
+        echo "0"
+    fi
+}
+
 get__fpm_footprint() {
     # Free footprint value for php-fpm
     # Check if current_fpm_footprint is an integer
@@ -91,7 +101,6 @@ set__system_addressbook_exposed() {
 	exec_occ config:app:set dav system_addressbook_exposed --value="$system_addressbook_exposed"
 	ynh_print_info "System addressbook is exposed: $system_addressbook_exposed"
 }
-
 
 set__enable_notify_push() {
     if [ "$enable_notify_push" -eq "0" ]; then
@@ -154,6 +163,19 @@ set__enable_notify_push() {
         ynh_print_info "Notify push enabled"
     fi
     ynh_app_setting_set --app=$app --key=enable_notify_push --value="$enable_notify_push"
+}
+
+set__enable_forward_email() {
+    if [ "$enable_forward_email" -eq "0" ]; then
+        exec_occ ldap:set-config "" ldapEmailAttribute "mail"
+        ynh_replace_string --match_string="\$this->updateEmail(\$ldapEntry\[\$attr\]\[1\]);" --replace_string="\$this->updateEmail(\$ldapEntry\[\$attr\]\[0\]);" --target_file="$install_dir/apps/user_ldap/lib/User/User.php"
+        ynh_store_file_checksum --file="$install_dir/apps/user_ldap/lib/User/User.php"
+    elif [ "$enable_forward_email" -eq "1" ]; then
+        exec_occ ldap:set-config "" ldapEmailAttribute "maildrop"
+        ynh_replace_string --match_string="\$this->updateEmail(\$ldapEntry\[\$attr\]\[0\]);" --replace_string="\$this->updateEmail(\$ldapEntry\[\$attr\]\[1\]);" --target_file="$install_dir/apps/user_ldap/lib/User/User.php"
+        ynh_store_file_checksum --file="$install_dir/apps/user_ldap/lib/User/User.php"
+    fi
+    ynh_app_setting_set --app=$app --key=enable_forward_email --value="$enable_forward_email"
 }
 
 set__fpm_footprint() {

--- a/tests.toml
+++ b/tests.toml
@@ -8,10 +8,10 @@ test_format = 1.0
     # Commits to test upgrade from
     # -------------------------------
 
-    test_upgrade_from.c5cf91ad.name = "Upgrade from 25.0.2"
-    test_upgrade_from.caf917f3.name = "Upgrade from 26.0.2"
-    test_upgrade_from.9c6d1eea.name = "Upgrade from 27.1.4"
-    test_upgrade_from.e9f82ab7.name = "Upgrade from 28.0.6"
+    #test_upgrade_from.c5cf91ad.name = "Upgrade from 25.0.2"
+    #test_upgrade_from.caf917f3.name = "Upgrade from 26.0.2"
+    #test_upgrade_from.9c6d1eea.name = "Upgrade from 27.1.4"
+    #test_upgrade_from.e9f82ab7.name = "Upgrade from 28.0.6"
     test_upgrade_from.541f5fde.name = "Upgrade from 29.0.8"
 
     [default.curl_tests]


### PR DESCRIPTION
## Problem

Be able to choose to use LDAP forward emails from LDAP as nextcloud users' email instead of main ynh LDAP emails.

## Solution

Add an option in config panel that change mail to maildrop in nextcloud LDAP setting and change $install_dir/apps/user_ldap/lib/User/User.php to retrieve the second value from the LDAP maildrop array as discuss in here : https://forum.yunohost.org/t/adresses-de-transfert-dans-ldap/31856

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
