### PR TITLE
Fix upgrade exploding when $app is nextcloud__2, __3 etc because the virtual apt/dpkg package is named with - and not _

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -74,7 +74,7 @@ exec_occ() {
     # will do magic regarding php configuration and $php_version when the php version of the dependencies changes ...
     php_version=$(ynh_app_setting_get --key=php_version)
     if [[ "$NEXTCLOUD_PHP_VERSION" != "$php_version" ]]; then
-        local pkg_dependencies="$(dpkg-query --show --showformat='${Depends}' ${app}-ynh-deps)"
+        local pkg_dependencies="$(dpkg-query --show --showformat='${Depends}' ${app///-}-ynh-deps)"
         pkg_dependencies="${pkg_dependencies//$php_version/$NEXTCLOUD_PHP_VERSION}"
         # Packaging v1 ~legacy : ynh_apt_install_dependencies is designed to be called several times
         # but the second time it will *append* the list of dependencies rather than replace the existing dependencies

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -74,7 +74,7 @@ exec_occ() {
     # will do magic regarding php configuration and $php_version when the php version of the dependencies changes ...
     php_version=$(ynh_app_setting_get --key=php_version)
     if [[ "$NEXTCLOUD_PHP_VERSION" != "$php_version" ]]; then
-        local pkg_dependencies="$(dpkg-query --show --showformat='${Depends}' ${app///-}-ynh-deps)"
+        local pkg_dependencies="$(dpkg-query --show --showformat='${Depends}' ${app//_/-}-ynh-deps)"
         pkg_dependencies="${pkg_dependencies//$php_version/$NEXTCLOUD_PHP_VERSION}"
         # Packaging v1 ~legacy : ynh_apt_install_dependencies is designed to be called several times
         # but the second time it will *append* the list of dependencies rather than replace the existing dependencies


### PR DESCRIPTION
## Problem

- *when multi instance the $app-ynh-deps need be formatted with Replace all '_' by '-', and append -ynh-deps*

## Solution

- *correct syntax from helpers*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
