### PR TITLE
Migrating the mimetypes

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -269,6 +269,11 @@ exec_occ config:import "$nc_conf"
 # Then remove the config file
 ynh_safe_rm "$nc_conf"
 
+# Occasionally new mimetypes are added to better handle certain file types.
+# Migrating the mimetypes take a long time on larger instances
+# so this is not done automatically during upgrades.
+exec_occ maintenance:repair --include-expensive
+
 #=================================================
 # ALLOW USERS TO DISCONNECT FROM NEXTCLOUD
 #=================================================


### PR DESCRIPTION
Occasionally new mimetypes are added to better handle certain file types.
Migrating the mimetypes take a long time on larger instances so this is not done automatically during upgrades.