### PR TITLE
[enh] Allow login by mail

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -50,7 +50,7 @@
       "ldap_groupfilter_objectclass": "posixGroup",
       "ldap_group_member_assoc_attribute": "memberUid",
       "ldap_host": "localhost",
-      "ldap_login_filter": "(&(|(objectclass=posixAccount))(uid=%uid)(permission=cn=__APP__.main,ou=permission,dc=yunohost,dc=org))",
+      "ldap_login_filter": "(&(|(objectclass=posixAccount))(|(uid=%uid)(mail=%uid))(permission=cn=__APP__.main,ou=permission,dc=yunohost,dc=org))",
       "ldap_login_filter_mode": "0",
       "ldap_port": "389",
       "ldap_quota_attr": "userquota",


### PR DESCRIPTION
## Problem

Related to https://github.com/YunoHost/yunohost/pull/2041

## Solution

Allow to login by mail

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

Tested on a prod setup by running:
```
yunohost app shell nextcloud
php ./occ ldap:set-config "" ldapLoginFilter "(&(|(objectclass=posixAccount))(|(uid=%uid)(mail=%uid))(permission=cn=nextcloud.main,ou=permission,dc=yunohost,dc=org))"
```

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
