### PR TITLE
[enh] Create custom fail2ban conf, with datepattern and more regex to catch

### DIFF
--- a/conf/f2b_filter.conf
+++ b/conf/f2b_filter.conf
@@ -1,0 +1,8 @@
+[INCLUDES]
+before = common.conf
+[Definition]
+_groupsre = (?:(?:,?\s*"\w+":(?:"[^"]+"|\w+))*)
+failregex = ^\{%(_groupsre)s,?\s*"remoteAddr":"<HOST>"%(_groupsre)s,?\s*"message":"Login failed:
+            ^\{%(_groupsre)s,?\s*"remoteAddr":"<HOST>"%(_groupsre)s,?\s*"message":"Two-factor challenge failed:
+            ^\{%(_groupsre)s,?\s*"remoteAddr":"<HOST>"%(_groupsre)s,?\s*"message":"Trusted domain error.
+datepattern = ,?\s*"time"\s*:\s*"%%Y-%%m-%%d[T ]%%H:%%M:%%S(%%z)?"

--- a/conf/f2b_jail.conf
+++ b/conf/f2b_jail.conf
@@ -1,0 +1,6 @@
+[__APP__]
+enabled = true
+port = http,https
+filter = __APP__
+logpath = /var/log/__APP__/nextcloud.log
+maxretry = 5

--- a/scripts/install
+++ b/scripts/install
@@ -284,7 +284,7 @@ ynh_config_add_logrotate
 ynh_script_progression "Configuring Fail2Ban..."
 
 # Create a dedicated Fail2Ban config
-ynh_config_add_fail2ban --logpath="/var/log/$app/nextcloud.log" --failregex="^.*Login failed: .* \(Remote IP: <HOST>.*$"
+ynh_config_add_fail2ban --logpath="/var/log/$app/nextcloud.log"
 
 #=================================================
 # CHECK IF NOTIFY_PUSH WORKS

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -429,7 +429,7 @@ ynh_config_add_logrotate
 #=================================================
 
 # Create a dedicated Fail2Ban config
-ynh_config_add_fail2ban --logpath="/var/log/$app/nextcloud.log" --failregex="^.*Login failed: .* \(Remote IP: <HOST>.*$"
+ynh_config_add_fail2ban --logpath="/var/log/$app/nextcloud.log"
 
 #=================================================
 # CHECK IF NOTIFY_PUSH WORKS


### PR DESCRIPTION
## Problem

- *No datepattern in the default conf*
- *Don't catch the error on F2A error*

## Solution

- *Use the f2b conf from the [doc](https://docs.nextcloud.com/server/latest/admin_manual/installation/harden_server.html#setup-a-filter-and-a-jail-for-nextcloud)*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
