### PR TITLE
Removing argument --file to calls of ynh_store_file_checksum helper

### DIFF
--- a/scripts/config
+++ b/scripts/config
@@ -132,11 +132,11 @@ set__enable_forward_email() {
     if [ "$enable_forward_email" -eq "0" ]; then
         exec_occ ldap:set-config "" ldapEmailAttribute "mail"
         ynh_replace --match="\$this->updateEmail(\$ldapEntry\[\$attr\]\[1\]);" --replace="\$this->updateEmail(\$ldapEntry\[\$attr\]\[0\]);" --file="$install_dir/apps/user_ldap/lib/User/User.php"
-        ynh_store_file_checksum --file="$install_dir/apps/user_ldap/lib/User/User.php"
+        ynh_store_file_checksum "$install_dir/apps/user_ldap/lib/User/User.php"
     elif [ "$enable_forward_email" -eq "1" ]; then
         exec_occ ldap:set-config "" ldapEmailAttribute "maildrop"
         ynh_replace --match="\$this->updateEmail(\$ldapEntry\[\$attr\]\[0\]);" --replace="\$this->updateEmail(\$ldapEntry\[\$attr\]\[1\]);" --file="$install_dir/apps/user_ldap/lib/User/User.php"
-        ynh_store_file_checksum --file="$install_dir/apps/user_ldap/lib/User/User.php"
+        ynh_store_file_checksum "$install_dir/apps/user_ldap/lib/User/User.php"
     fi
     ynh_app_setting_set --app=$app --key=enable_forward_email --value="$enable_forward_email"
 }


### PR DESCRIPTION
As the usage is `ynh_store_file_checksum /path/to/file` as stated on https://github.com/YunoHost/yunohost/blob/main/helpers/helpers.v2.1.d/backup#L225

## Problem

- Described on the forum: https://forum.yunohost.org/t/configuration-panel-not-accessible-for-an-app-nextcloud-after-making-a-change/35921

## Solution

- Calling the helper ynh_store_file_checksum correctly.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
