### PR TITLE
Reset password

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -11,7 +11,7 @@
       "timeout": "0.0",
       "password": ""
      },
-    "lost_password_link" => "https://lestoitspartages.fr/yunohost/sso/password.html",
+    "lost_password_link" => "https://$domain$path/sso/password.html",
     "hashing_default_password": true,
     "localstorage.allowsymlinks": true,
     "simpleSignUpLink.shown": false,

--- a/conf/config.json
+++ b/conf/config.json
@@ -11,6 +11,7 @@
       "timeout": "0.0",
       "password": ""
      },
+    "lost_password_link" => "https://lestoitspartages.fr/yunohost/sso/password.html",
     "hashing_default_password": true,
     "localstorage.allowsymlinks": true,
     "simpleSignUpLink.shown": false,


### PR DESCRIPTION
## Problem

To redirect the "I Forgot my pasword" button to the yunohost password page.

## Solution

I base my work on https://help.nextcloud.com/t/remove-the-possibility-to-reset-password-for-users/27570/2 but I'm not quiet sure about the url I wrote https://$domain$path/sso/password.html and I didn't test it yet.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
