### PR TITLE
Fix inconsistent php version during upgrade with OCC

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -208,16 +208,16 @@ do
     ynh_safe_rm "$install_dir"
     mv "$tmpdir" "$install_dir"
 
+    # Get the new current version number
+    current_version=$(grep OC_VersionString "$install_dir/version.php" | cut -d\' -f2)
+    current_major_version=${current_version%%.*}
+    
     # Set write access for the following commands
     chown -R $app:www-data "$install_dir"
     # Upgrade Nextcloud (SUCCESS = 0, UP_TO_DATE = 3)
     exec_occ maintenance:mode --off
     exec_occ upgrade || [ $? -eq 3 ] || ynh_die "Unable to upgrade $app"
 
-    # Get the new current version number
-    current_version=$(grep OC_VersionString "$install_dir/version.php" | cut -d\' -f2)
-    current_major_version=${current_version%%.*}
-    
     # Print the current version number of Nextcloud
     exec_occ -V
 done


### PR DESCRIPTION
## Problem

cf https://forum.yunohost.org/t/update-from-nextcloud-30-to-31-fails/37151

In some scenarios, during the upgrade, we run the `occ upgrade` command with the PHP version for the "previous" version ... yet some code may not be backward compatible (in the case of the previous forum thread : the password extension used a new feature of php 8.3 but the code was being run with php 8.2) 

## Solution

The fix should in fact be pretty simple, we need to update `$current_major_version` as soon as we update the code in `$install_dir` to keep everything consistent
