### PR TITLE
Manage oldstable version (#714)

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -25,6 +25,19 @@ name.fr = "Configuration de Nextcloud"
         help.en = "This action sets permissions for all data. Beware, this action can take up to several hours if users have a lot of data."
         help.fr = "Cette action définit les autorisations pour toutes les données. Attention, cette action peut prendre jusqu'à plusieurs heures si les utilisateurs ont beaucoup de données."
 
+    [main.version]
+    name.en = "Upgrade channel"
+    name.fr = "Canal de mise à jour"
+    
+        [main.version.version_to_follow]
+        ask.en = "Upgrade channel to use"
+        ask.fr = "Canal de mise à jour à utiliser"
+        type = "select"
+        choices = ["stable", "oldstable"]
+        default = "stable"
+        help.en = "Stable releases (latest Nextcloud version available) sometimes contain annoying bugs or regressions. Using the oldstable channel (one version behind the latest) during this period can be useful if you need high stability."
+        help.fr = "Les versions stables (dernière version Nextcloud disponible) contiennent parfois des bugs ou des régressions gênants. Utiliser le canal oldstable (une version en retard sur la dernière) pendant cette période peut être utile si vous avez besoin d'une grande stabilité."
+
     [main.addressbook]
     name.en = "Address book configuration"
     name.fr = "Configuration du carnet d'adresses"

--- a/manifest.toml
+++ b/manifest.toml
@@ -56,6 +56,15 @@ ram.runtime = "512M"
     type = "boolean"
     default = false
 
+    [install.version_to_follow]
+    ask.en = "Upgrade channel to use"
+    ask.fr = "Canal de mise à jour à utiliser"
+    help.en = "Stable releases (latest Nextcloud version available) sometimes contain annoying bugs or regressions. Using the oldstable channel (one version behind the latest) during this period can be useful if you need high stability."
+    help.fr = "Les versions stables (dernière version Nextcloud disponible) contiennent parfois des bugs ou des régressions gênants. Utiliser le canal oldstable (une version en retard sur la dernière) pendant cette période peut être utile si vous avez besoin d'une grande stabilité."
+    type = "select"
+    choices = ["stable", "oldstable"]
+    default = "stable"
+    
 [resources]
 
     [resources.sources]

--- a/scripts/install
+++ b/scripts/install
@@ -34,7 +34,17 @@ ynh_mysql_db_shell <<< "ALTER DATABASE $db_name CHARACTER SET utf8mb4 COLLATE ut
 #=================================================
 ynh_script_progression "Setting up source files..."
 
-ynh_setup_source --dest_dir="$install_dir"
+# Enable YunoHost patches on Nextcloud sources
+cp -a ../sources/patches_last_version/* ../sources/patches
+
+source_id="main"
+if [ "$version_to_follow" == "oldstable" ]; then
+    last_version=$(ynh_read_manifest --manifest_key="resources.sources.main.url" | grep -o '[0-9][0-9]\.[0-9]\.[0-9]')
+    last_major_version=${last_version%%.*}
+    last_major_version=$(( $last_major_version - 1 ))
+fi
+# Download, check integrity, uncompress and patch the source from app.src
+ynh_setup_source --dest_dir="$install_dir" --source_id="$source_id"
 
 #=================================================
 # PHP-FPM CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -41,6 +41,12 @@ then
     ynh_die "Upgrading from Nextcloud < 22.2 is not supported anymore. You should first upgrade to 22.2 using: yunohost app upgrade nextcloud -u https://github.com/YunoHost-Apps/nextcloud_ynh/tree/41f5f902e7c7cd3c30a6793020562ba98b9bf3e9"
 fi
 
+if [ -z "${version_to_follow:-}" ]
+then
+    version_to_follow=stable
+    ynh_app_setting_set --app=$app --key=version_to_follow --value="$version_to_follow"
+fi
+
 #=================================================
 # MAKE SEQUENTIAL UPGRADES FROM EACH MAJOR
 # VERSION TO THE NEXT ONE
@@ -127,6 +133,11 @@ current_major_version=${current_version%%.*}
 
 last_version=$(ynh_read_manifest "resources.sources.main.url" | grep -Eo '[0-9][0-9]\.[0-9]\.[0-9]+')
 last_major_version=${last_version%%.*}
+if [[ "$version_to_follow" == "oldstable" ]]
+then
+    last_major_version=$(( $last_major_version - 1 ))
+    last_version=$(ynh_read_manifest --manifest_key="resources.sources.${last_major_version}.url" | grep -o '[0-9][0-9]\.[0-9]\.[0-9]')
+fi
 
 if [[ "$last_major_version" != "$current_major_version" ]]
 then
@@ -235,12 +246,158 @@ ynh_script_progression "Reconfiguring $app..."
 # Verify the checksum and backup the file if it's different
 ynh_backup_if_checksum_is_different "$install_dir/config/config.php"
 
-nc_conf="${install_dir}/config.json"
-ynh_config_add --template="config.json" --destination="$nc_conf"
+    # While the current version is not the last version, do an upgrade
+    while [[ "$last_version" > "$current_version" ]]
+    do
+        next_major_version="$(( $current_major_version + 1 ))"
+        source_id="$next_major_version"
+        if [[ "$next_major_version" -ge "$last_major_version" ]]; then
+            ynh_print_info "Upgrading to Nextcloud $last_version"
+            if [[ "$version_to_follow" != "oldstable" ]]
+            then
+                source_id="main"
+            fi
+        else
+            ynh_print_info "Upgrading to Nextcloud $next_major_version"
+        fi
 
-# Reneable the mail app
-if [ $mail_app_must_be_reactived -eq 1 ]; then
-    exec_occ app:enable mail
+        # Create a temporary directory
+        tmpdir="${install_dir}__tmp_upgrade"
+
+        ynh_setup_source --dest_dir="$tmpdir" --source_id="$source_id"
+
+        # Backup the config file in the temp dir
+        cp -a "$install_dir/config/config.php" "$tmpdir/config/config.php"
+
+        # Enable maintenance mode
+        exec_occ maintenance:mode --on
+
+        # Backup 3rd party applications from the current Nextcloud
+        # But do not overwrite if there is any upgrade
+        # (apps directory already exists in Nextcloud archive)
+        (
+        cd $install_dir/apps
+        for nc_app_dir in */
+        do
+          if [ ! -d "$tmpdir/apps/$nc_app_dir" ]
+          then
+            cp -a "$nc_app_dir" "$tmpdir/apps/$nc_app_dir"
+          fi
+        done
+        )
+
+        # Replace the old Nextcloud by the new one
+        ynh_safe_rm "$install_dir"
+        mv "$tmpdir" "$install_dir"
+
+        # Set write access for the following commands
+        chown -R $app:www-data "$install_dir"
+        # Upgrade Nextcloud (SUCCESS = 0, UP_TO_DATE = 3)
+        exec_occ maintenance:mode --off
+        exec_occ upgrade || [ $? -eq 3 ] || ynh_die "Unable to upgrade $app"
+
+        # Get the new current version number
+        current_version=$(grep OC_VersionString "$install_dir/version.php" | cut -d\' -f2)
+        current_major_version=${current_version%%.*}
+
+        # Print the current version number of Nextcloud
+        exec_occ -V
+    done
+
+    exec_occ db:add-missing-indices -n
+    exec_occ db:add-missing-columns -n
+    exec_occ db:add-missing-primary-keys -n
+    exec_occ db:convert-filecache-bigint -n
+
+    #=================================================
+    # CONFIGURE NEXTCLOUD
+    #=================================================
+    ynh_script_progression "Reconfiguring $app..."
+
+    # Verify the checksum and backup the file if it's different
+    ynh_backup_if_checksum_is_different "$install_dir/config/config.php"
+
+    nc_conf="${install_dir}/config.json"
+    ynh_config_add --template="config.json" --destination="$nc_conf"
+
+    # Reneable the mail app
+    if [ $mail_app_must_be_reactived -eq 1 ]; then
+        exec_occ app:enable mail
+    fi
+
+    # Ensure that UpdateNotification app is disabled
+    exec_occ app:disable updatenotification
+
+    # Enable LDAP plugin
+    exec_occ app:enable user_ldap
+
+    # Update all installed apps
+    exec_occ app:update --all
+
+    # move the logs from the data_dir to the standard /var/log
+    # it would be better in the ENSURE DOWNWARD COMPATIBILITY section
+    # but it must be after the exec_occ() definition, so it's here
+    if [ -f "$data_dir/data/nextcloud.log" ]; then
+        mkdir -p "/var/log/$app"
+        chmod 750 "/var/log/$app"
+        mv "$data_dir"/data/nextcloud.log* "/var/log/$app"
+        # adapt the nextcloud config
+        exec_occ config:system:set logfile --value="/var/log/$app/nextcloud.log"
+    fi
+
+    # Load the config file in nextcloud
+    exec_occ config:import "$nc_conf"
+
+    # Then remove the config file
+    ynh_safe_rm "$nc_conf"
+
+    #=================================================
+    # ALLOW USERS TO DISCONNECT FROM NEXTCLOUD
+    #=================================================
+
+    # Add dynamic logout URL to the config
+    url_base64="$(echo -n "https://$domain$path" | base64)"
+    old_logout_url="https://$(cat /etc/yunohost/current_host)/yunohost/sso/?action=logout"
+    current_logout_url="$(exec_occ config:system:get logout_url 2> /dev/null)"
+    if [[ "$current_logout_url" == "${old_logout_url}" ]] || [[ "$current_logout_url" == "" ]]
+    then
+        echo "
+    //-YunoHost-
+    // set logout_url according to main domain
+    \$main_domain = file_get_contents('/etc/yunohost/current_host');
+    \$CONFIG['logout_url'] = 'https://'.\$main_domain.'/yunohost/sso/?action=logout&r=${url_base64}';
+    //-YunoHost-
+        " >> "$install_dir/config/config.php"
+    fi
+
+    #=================================================
+    # CHANGE HOSTNAME FOR ACTIVITY NOTIFICATIONS
+    #=================================================
+
+    exec_occ config:system:set overwrite.cli.url --value="https://${domain}${path}"
+
+    #=================================================
+    # MOUNT HOME FOLDERS AS EXTERNAL STORAGE
+    #=================================================
+
+    # Enable External Storage and create local mount to home folder as needed
+    if [ $user_home -eq 1 ]; then
+        exec_occ app:enable files_external
+        exec_occ files_external:list --output=json \
+        | grep -q '"storage":"\\\\OC\\\\Files\\\\Storage\\\\Local"' \
+        || create_external_storage "/home/\$user" "Home"
+        # Iterate over users to extend their home folder permissions
+        for u in $(ynh_user_list); do
+        setfacl --modify g:$app:rwx "/home/$u" || true
+        done
+    fi
+
+    #=================================================
+    # STORE THE CHECKSUM OF THE CONFIG FILE
+    #=================================================
+
+    # Calculate and store the config file checksum into the app settings
+    ynh_store_file_checksum "${install_dir}/config/config.php"
 fi
 
 # Ensure that UpdateNotification app is disabled

--- a/tests.toml
+++ b/tests.toml
@@ -2,6 +2,7 @@ test_format = 1.0
 
 [default]
 
+    args.version_to_follow = "stable"
     args.enable_notify_push = "0"
 
     # -------------------------------
@@ -37,8 +38,12 @@ test_format = 1.0
     caldav.logged_on_sso = true
     caldav.expect_content = "This is the WebDAV interface."
 
-#[notify_push_test]
-
-#    args.enable_notify_push = "1"
-#    test_upgrade_from.e9f82ab7.name = "Upgrade from 28.0.6"
-#    test_upgrade_from.e9f82ab7.args.system_addressbook_exposed = "yes"
+[oldstable]
+    args.version_to_follow = "oldstable"
+    test_upgrade_from.e9f82ab7.name = "Upgrade from 28.0.6"
+    test_upgrade_from.e9f82ab7.args.system_addressbook_exposed = "yes"
+    
+[notify_push_test]
+    args.enable_notify_push = "1"
+    test_upgrade_from.e9f82ab7.name = "Upgrade from 28.0.6"
+    test_upgrade_from.e9f82ab7.args.system_addressbook_exposed = "yes"


### PR DESCRIPTION
## Problem
I squash merged https://github.com/YunoHost-Apps/nextcloud_ynh/pull/714 into this branch cause there are a lot of unrelated commits in history...

We need a way to follow the N-1 version (oldstable) cause it's generally, more stable, than stable :/

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
