### PR TITLE
[fix] Upgrade remove executable perm for nc extension

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -335,6 +335,7 @@ ynh_script_progression "Reapplying file permissions..."
 chown -R $app:www-data "$install_dir"
 find $install_dir/ -type f -print0 | xargs -r0 chmod 0644
 find $install_dir/ -type d -print0 | xargs -r0 chmod 0755
+find "$install_dir/apps/"*/{bin,bin-ext} -type d -print0 | xargs -r0 chmod -R u+x
 chmod 600 "$install_dir/config/config.php"
 chmod 755 /home/yunohost.app
 chmod 750 $install_dir


### PR DESCRIPTION
## Problem
https://github.com/YunoHost-Apps/nextcloud_ynh/issues/811

## Solution
Add executable perm on bin dir of apps.

Note that in some situation where an attacker is able to write a bin dir in an app dir, it could open the door to execute a script after the app upgrade...

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
