### PR TITLE
Fix acl restore

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -151,6 +151,8 @@ then
     # Iterate over users to extend their home folder permissions
     for u in $(ynh_user_list); do
         setfacl --recursive --modify g:$app:rwX,d:g:$app:rwX "/home/$u" || true
+        # Avoid leaving acl on .ssh, which could prevent users from connecting
+        setfacl --recursive -bn "/home/$u/.ssh" || true
     done
 fi
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -75,6 +75,8 @@ chmod 750 $install_dir
 if [ $user_home -eq 1 ]; then 
     for u in $(ynh_user_list); do
         setfacl --recursive --modify g:$app:rwX,d:g:$app:rwX "/home/$u" || true
+        # Avoid leaving acl on .ssh, which could prevent users from connecting
+        setfacl --recursive -bn "/home/$u/.ssh" || true
     done
 fi
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -72,9 +72,11 @@ chmod 750 $install_dir
 
 # Iterate over users to extend their home folder permissions - for the external
 # storage plugin usage - and create relevant Nextcloud directories
-for u in $(ynh_user_list); do
-    setfacl --recursive --modify g:$app:rwX,d:g:$app:rwX "/home/$u" || true
-done
+if [ $user_home -eq 1 ]; then 
+    for u in $(ynh_user_list); do
+        setfacl --recursive --modify g:$app:rwX,d:g:$app:rwX "/home/$u" || true
+    done
+fi
 
 #=================================================
 # YUNOHOST MULTIMEDIA INTEGRATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -317,7 +317,9 @@ if [ $user_home -eq 1 ]; then
     || create_external_storage "/home/\$user" "Home"
     # Iterate over users to extend their home folder permissions
     for u in $(ynh_user_list); do
-    setfacl --modify g:$app:rwx "/home/$u" || true
+        setfacl --modify g:$app:rwx "/home/$u" || true
+        # Avoid leaving acl on .ssh, which could prevent users from connecting
+        setfacl --recursive -bn "/home/$u/.ssh" || true
     done
 fi
 


### PR DESCRIPTION
## Problem

- Closes #899. I can target master with this PR if you prefer.

## Solution

- Check for `$user_home` before restoring acls

Note that I do not yet change permissions on .ssh. I think this is the more important fix. ~~I will make another PR to address that other case.~~ Update: added a commit that removes ACLs on .ssh specifically. A better approach may be to backup the previous value, but this will fix previously changed values, and I doubt that there is a valid use-case for other ACLs on that folder.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
